### PR TITLE
Add init modules and model registry

### DIFF
--- a/xtylearner/__init__.py
+++ b/xtylearner/__init__.py
@@ -1,0 +1,14 @@
+"""Core package for XTYLearner models and training utilities."""
+
+from .models import CycleDual, MixtureOfFlows, MultiTask, get_model
+from .training import M2VAE, SS_CEVAE, train_self_supervised
+
+__all__ = [
+    "CycleDual",
+    "MixtureOfFlows",
+    "MultiTask",
+    "get_model",
+    "M2VAE",
+    "SS_CEVAE",
+    "train_self_supervised",
+]

--- a/xtylearner/configs/__init__.py
+++ b/xtylearner/configs/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration files for experiments."""

--- a/xtylearner/data/__init__.py
+++ b/xtylearner/data/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset utilities for XTYLearner."""

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -1,0 +1,13 @@
+"""Model architectures available in XTYLearner."""
+
+from .cycle_dual import CycleDual
+from .flow_ssc import MixtureOfFlows
+from .multitask_selftrain import MultiTask
+from .registry import get_model
+
+__all__ = [
+    "CycleDual",
+    "MixtureOfFlows",
+    "MultiTask",
+    "get_model",
+]

--- a/xtylearner/models/registry.py
+++ b/xtylearner/models/registry.py
@@ -1,1 +1,22 @@
-## `get_model(name, **hparams)` factory
+"""Simple registry for constructing model classes by name."""
+
+from typing import Type, Dict
+
+from .cycle_dual import CycleDual
+from .flow_ssc import MixtureOfFlows
+from .multitask_selftrain import MultiTask
+
+_MODEL_REGISTRY: Dict[str, Type] = {
+    "cycle_dual": CycleDual,
+    "flow_ssc": MixtureOfFlows,
+    "multitask": MultiTask,
+}
+
+
+def get_model(name: str, **hparams):
+    """Instantiate a model from the registry."""
+    if name not in _MODEL_REGISTRY:
+        raise ValueError(f"Unknown model '{name}'. Available: {list(_MODEL_REGISTRY)}")
+    return _MODEL_REGISTRY[name](**hparams)
+
+__all__ = ["get_model"]

--- a/xtylearner/scripts/__init__.py
+++ b/xtylearner/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Command line entry points for XTYLearner."""

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -1,0 +1,5 @@
+"""Training utilities and trainer implementations."""
+
+from .base_trainer import M2VAE, SS_CEVAE, train_self_supervised
+
+__all__ = ["M2VAE", "SS_CEVAE", "train_self_supervised"]


### PR DESCRIPTION
## Summary
- expose package API by adding `__init__` modules
- implement a simple model registry helper

## Testing
- `python -m pip install --no-deps -e .`

------
https://chatgpt.com/codex/tasks/task_e_68688d1cd8ec83248afeaa70802b2195