### PR TITLE
Add model registry decorator

### DIFF
--- a/xtylearner/models/cycle_dual.py
+++ b/xtylearner/models/cycle_dual.py
@@ -8,6 +8,8 @@
 import torch, torch.nn as nn
 from torch.nn.functional import one_hot, cross_entropy
 
+from .registry import register_model
+
 # ---------- tiny helper MLP ---------------------------------------------
 def mlp(in_dim, out_dim, hidden=128):
     return nn.Sequential(
@@ -16,6 +18,7 @@ def mlp(in_dim, out_dim, hidden=128):
         nn.Linear(hidden, out_dim))
 
 # ---------- dual-network module -----------------------------------------
+@register_model("cycle_dual")
 class CycleDual(nn.Module):
     """
     G_Y : (X ⊕ onehot(T)) → Ŷ

--- a/xtylearner/models/flow_ssc.py
+++ b/xtylearner/models/flow_ssc.py
@@ -14,6 +14,8 @@ from nflows.flows.base import Flow
 from nflows.transforms import CompositeTransform, ReversePermutation, AffineCouplingTransform
 from nflows.nn.nets import ResidualNet
 
+from .registry import register_model
+
 
 def make_conditional_flow(dim_xy: int, context_dim: int,
                           n_layers: int = 6, hidden: int = 128) -> Flow:
@@ -34,6 +36,7 @@ def make_conditional_flow(dim_xy: int, context_dim: int,
     return Flow(CompositeTransform(transforms), StandardNormal([dim_xy]))
 
 
+@register_model("flow_ssc")
 class MixtureOfFlows(nn.Module):
     """
     * one conditional flow  p_theta(x,y | t)  (context = one-hot(t))

--- a/xtylearner/models/multitask_selftrain.py
+++ b/xtylearner/models/multitask_selftrain.py
@@ -16,6 +16,8 @@
 import torch, torch.nn as nn
 from torch.nn.functional import one_hot, cross_entropy, mse_loss
 
+from .registry import register_model
+
 # ------------------------------------------------------------
 # shared encoder for any vector input -------------------------
 def mlp(in_dim, out_dim, hidden=128):
@@ -24,6 +26,7 @@ def mlp(in_dim, out_dim, hidden=128):
         nn.Linear(hidden, hidden), nn.ReLU(),
         nn.Linear(hidden, out_dim))
 
+@register_model("multitask")
 class MultiTask(nn.Module):
     """
     h               : shared encoder from X  → ℝ^h

--- a/xtylearner/models/registry.py
+++ b/xtylearner/models/registry.py
@@ -1,22 +1,29 @@
 """Simple registry for constructing model classes by name."""
 
-from typing import Type, Dict
+from typing import Callable, Dict, Any
 
-from .cycle_dual import CycleDual
-from .flow_ssc import MixtureOfFlows
-from .multitask_selftrain import MultiTask
-
-_MODEL_REGISTRY: Dict[str, Type] = {
-    "cycle_dual": CycleDual,
-    "flow_ssc": MixtureOfFlows,
-    "multitask": MultiTask,
-}
+# Mapping from model names to their constructors.  Model files register
+# themselves here via the :func:`register_model` decorator below.
+_MODEL_REGISTRY: Dict[str, Callable[..., Any]] = {}
 
 
-def get_model(name: str, **hparams):
+def register_model(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a model class under ``name``."""
+
+    def decorator(cls: Callable[..., Any]) -> Callable[..., Any]:
+        _MODEL_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_model(name: str, **hparams: Any) -> Any:
     """Instantiate a model from the registry."""
     if name not in _MODEL_REGISTRY:
-        raise ValueError(f"Unknown model '{name}'. Available: {list(_MODEL_REGISTRY)}")
+        raise ValueError(
+            f"Unknown model '{name}'. Available: {list(_MODEL_REGISTRY)}"
+        )
     return _MODEL_REGISTRY[name](**hparams)
 
-__all__ = ["get_model"]
+
+__all__ = ["register_model", "get_model"]


### PR DESCRIPTION
## Summary
- create registry with `register_model` decorator and `get_model`
- register `CycleDual`, `MixtureOfFlows`, and `MultiTask` via decorator

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6868916a0b0483248202607e1574f868