### PR TITLE
Implement dataset loaders

### DIFF
--- a/xtylearner/data/__init__.py
+++ b/xtylearner/data/__init__.py
@@ -1,1 +1,46 @@
 """Dataset utilities for XTYLearner."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .toy_dataset import load_toy_dataset
+from .synthetic_dataset import load_synthetic_dataset
+from .ihdp_dataset import load_ihdp
+from .twins_dataset import load_twins
+
+
+_DATASETS: Dict[str, Callable[..., object]] = {
+    "toy": load_toy_dataset,
+    "synthetic": load_synthetic_dataset,
+    "ihdp": load_ihdp,
+    "twins": load_twins,
+}
+
+
+def get_dataset(name: str, **kwargs):
+    """Load one of the built-in datasets by name.
+
+    Parameters
+    ----------
+    name:
+        Name of the dataset.  One of ``"toy"``, ``"synthetic"``,
+        ``"ihdp"`` or ``"twins"``.
+    **kwargs:
+        Additional keyword arguments forwarded to the dataset loader.
+
+    Returns
+    -------
+    ``torch.utils.data.Dataset``
+        The requested dataset object.
+    """
+
+    name = name.lower()
+    if name not in _DATASETS:
+        raise ValueError(f"Unknown dataset '{name}'")
+    return _DATASETS[name](**kwargs)
+
+
+__all__ = ["get_dataset", "load_toy_dataset", "load_synthetic_dataset", "load_ihdp", "load_twins"]
+
+

--- a/xtylearner/data/ihdp_dataset.py
+++ b/xtylearner/data/ihdp_dataset.py
@@ -1,1 +1,48 @@
-# IHDP (Infant Health and Development Program) Dataset
+"""Utility functions for the IHDP (Infant Health and Development Program) dataset.
+
+The loader downloads the semi-synthetic dataset released with the
+``CEVAE`` paper if it is not already present locally.  It returns a
+``TensorDataset`` containing covariates ``X``, outcomes ``Y`` and
+treatment labels ``T`` with shapes ``(N, d_x)``, ``(N, 1)`` and
+``(N,)`` respectively.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+from urllib.request import urlretrieve
+
+URLS = {
+    "train": "https://github.com/AMLab-Amsterdam/CEVAE/raw/master/datasets/ihdp_npci_1-100.train.npz",
+    "test": "https://github.com/AMLab-Amsterdam/CEVAE/raw/master/datasets/ihdp_npci_1-100.test.npz",
+}
+
+
+def load_ihdp(
+    split: Literal["train", "test"] = "train",
+    data_dir: str = "~/.xtylearner/data",
+) -> TensorDataset:
+    """Download (if needed) and load the IHDP dataset."""
+
+    url = URLS[split]
+    path = Path(data_dir).expanduser()
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / Path(url).name
+    if not file_path.exists():
+        urlretrieve(url, file_path.as_posix())
+
+    data = np.load(file_path)
+    X = torch.from_numpy(data["x"]).float()
+    Y = torch.from_numpy(data["yf"]).float().unsqueeze(-1)
+    T = torch.from_numpy(data["t"]).long()
+
+    return TensorDataset(X, Y, T)
+
+
+__all__ = ["load_ihdp"]
+

--- a/xtylearner/data/synthetic_dataset.py
+++ b/xtylearner/data/synthetic_dataset.py
@@ -1,1 +1,45 @@
-# a more complex synthetic datset for benchmarking and testing
+"""Synthetic benchmark dataset used for experiments.
+
+The dataset is generated procedurally using a simple structural model.
+It provides covariates ``X``, outcomes ``Y`` and treatment labels
+``T``.  Shapes are ``X`` of shape ``(n_samples, d_x)``, ``Y`` of shape
+``(n_samples, 1)`` and ``T`` of shape ``(n_samples,)``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.datasets import make_regression
+import torch
+from torch.utils.data import TensorDataset
+
+
+def load_synthetic_dataset(
+    n_samples: int = 1000,
+    d_x: int = 5,
+    seed: int = 0,
+) -> TensorDataset:
+    """Generate a moderately sized synthetic benchmark dataset."""
+
+    rng = np.random.default_rng(seed)
+    X, _ = make_regression(
+        n_samples=n_samples, n_features=d_x, noise=0.1, random_state=seed
+    )
+    X = X.astype(np.float32)
+
+    w_t = rng.normal(size=d_x)
+    logits_t = X @ w_t
+    p_t = 1.0 / (1.0 + np.exp(-logits_t))
+    T = rng.binomial(1, p_t).astype(np.int64)
+
+    w_y = rng.normal(size=d_x)
+    Y = X @ w_y + 2.0 * T + rng.normal(scale=0.1, size=n_samples)
+    Y = Y.astype(np.float32)
+
+    return TensorDataset(
+        torch.from_numpy(X), torch.from_numpy(Y).unsqueeze(-1), torch.from_numpy(T)
+    )
+
+
+__all__ = ["load_synthetic_dataset"]
+

--- a/xtylearner/data/toy_dataset.py
+++ b/xtylearner/data/toy_dataset.py
@@ -1,1 +1,55 @@
-# a simple, tiny synthetic dataset for demonstrations
+"""Tiny toy dataset used for quick demonstrations.
+
+This dataset is completely synthetic and generated on the fly.  It is
+useful for unit tests or simple sanity checks.  The returned
+``TensorDataset`` contains three tensors: covariates ``X`` of shape
+``(n_samples, d_x)``, outcomes ``Y`` of shape ``(n_samples, 1)`` and a
+binary treatment label ``T`` of shape ``(n_samples,)``.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+
+
+def load_toy_dataset(
+    n_samples: int = 100,
+    d_x: int = 2,
+    seed: int = 0,
+) -> TensorDataset:
+    """Generate a simple synthetic dataset.
+
+    Parameters
+    ----------
+    n_samples:
+        Number of data points to generate.
+    d_x:
+        Dimensionality of the covariates.
+    seed:
+        Random seed used for reproducibility.
+
+    Returns
+    -------
+    TensorDataset
+        Dataset containing ``(X, Y, T)`` tensors.
+    """
+
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n_samples, d_x)).astype(np.float32)
+    T = rng.integers(0, 2, size=n_samples).astype(np.int64)
+
+    beta = rng.normal(size=d_x)
+    Y = X @ beta + 0.5 * T + rng.normal(scale=0.1, size=n_samples)
+    Y = Y.astype(np.float32)
+
+    return TensorDataset(
+        torch.from_numpy(X), torch.from_numpy(Y).unsqueeze(-1), torch.from_numpy(T)
+    )
+
+
+__all__ = ["load_toy_dataset"]
+

--- a/xtylearner/data/twins_dataset.py
+++ b/xtylearner/data/twins_dataset.py
@@ -1,1 +1,45 @@
-# Twin US births in 1989-1991.
+"""Utilities for the Twins dataset consisting of US twin births.
+
+The dataset was introduced in the "Inferring Individual Treatment
+Effects from Randomized Trials" paper and is often used for evaluating
+causal inference methods.  The loader downloads a processed CSV file if
+it is not already available.  It returns a ``TensorDataset`` with
+covariates ``X`` of shape ``(N, d_x)``, outcomes ``Y`` of shape
+``(N, 1)`` and binary treatment indicators ``T`` of shape ``(N,)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+from urllib.request import urlretrieve
+
+URL = "https://raw.githubusercontent.com/py-why/benchmark-datasets/main/twins/twin_pairs.csv"
+
+
+def load_twins(data_dir: str = "~/.xtylearner/data") -> TensorDataset:
+    """Download (if necessary) and load the Twins dataset."""
+
+    path = Path(data_dir).expanduser()
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / "twin_pairs.csv"
+    if not file_path.exists():
+        urlretrieve(URL, file_path.as_posix())
+
+    data = np.genfromtxt(file_path, delimiter=",", names=True)
+    T = data["treatment"].astype(np.int64)
+    Y = data["outcome"].astype(np.float32)
+    cov_names = [n for n in data.dtype.names if n not in {"treatment", "outcome"}]
+    X = np.vstack([data[n] for n in cov_names]).T.astype(np.float32)
+
+    return TensorDataset(
+        torch.from_numpy(X), torch.from_numpy(Y).unsqueeze(-1), torch.from_numpy(T)
+    )
+
+
+__all__ = ["load_twins"]
+


### PR DESCRIPTION
## Summary
- implement simple toy, synthetic, IHDP and Twins dataset loaders
- add a `get_dataset` utility that dispatches by name
- describe expected tensor shapes in dataset docstrings

## Testing
- `python -m py_compile xtylearner/data/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68689c18b27c83249d286a99da0bda83