### PR TITLE
Add configuration defaults and loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "torch",
     "scikit-learn",
     "numpy",
-    "nflows"
+    "nflows",
+    "pyyaml"
 ]
 
 [project.scripts]

--- a/xtylearner/__init__.py
+++ b/xtylearner/__init__.py
@@ -1,7 +1,7 @@
 """Core package for XTYLearner models and training utilities."""
 
 from .models import CycleDual, MixtureOfFlows, MultiTask, get_model
-from .training import M2VAE, SS_CEVAE, train_self_supervised
+from .training import M2VAE, SS_CEVAE
 
 __all__ = [
     "CycleDual",
@@ -10,5 +10,4 @@ __all__ = [
     "get_model",
     "M2VAE",
     "SS_CEVAE",
-    "train_self_supervised",
 ]

--- a/xtylearner/configs/__init__.py
+++ b/xtylearner/configs/__init__.py
@@ -1,1 +1,29 @@
 """Configuration files for experiments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load(path: str | Path) -> Dict[str, Any]:
+    """Load a YAML configuration file.
+
+    Parameters
+    ----------
+    path:
+        Path to the ``.yaml`` file to load.
+
+    Returns
+    -------
+    dict
+        Parsed configuration dictionary.
+    """
+
+    with Path(path).expanduser().open("r") as f:
+        return yaml.safe_load(f)
+
+
+__all__ = ["load"]

--- a/xtylearner/configs/default.yaml
+++ b/xtylearner/configs/default.yaml
@@ -1,0 +1,28 @@
+# Default experiment configuration for XTYLearner
+
+# Dataset selection and options
+# Name corresponds to built-in loaders in ``xtylearner.data``
+dataset:
+  name: toy
+  params:
+    n_samples: 100
+    d_x: 2
+
+# Model hyper-parameters
+model:
+  # One of the architectures defined in ``xtylearner.training`` or ``xtylearner.models``
+  name: m2_vae
+  params:
+    d_x: 2
+    d_y: 1
+    k: 2
+    d_z: 16
+    tau: 0.5
+
+# Training options
+training:
+  # Trainer class to use from ``xtylearner.training``
+  trainer: M2VAETrainer
+  batch_size: 32
+  learning_rate: 0.001
+  epochs: 5

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -8,10 +8,20 @@ from torch.nn.functional import one_hot, softmax, gumbel_softmax
 from torch.distributions import Normal
 
 from .base_trainer import BaseTrainer
-from ..models.m2_vae import EncoderZ as M2EncoderZ, ClassifierT as M2ClassifierT,
-    DecoderX as M2DecoderX, DecoderT as M2DecoderT, DecoderY as M2DecoderY
-from ..models.cevae_ss import EncoderZ as CEncoderZ, ClassifierT as CClassifierT,
-    DecoderX as CDecoderX, DecoderT as CDecoderT, DecoderY as CDecoderY
+from ..models.m2_vae import (
+    EncoderZ as M2EncoderZ,
+    ClassifierT as M2ClassifierT,
+    DecoderX as M2DecoderX,
+    DecoderT as M2DecoderT,
+    DecoderY as M2DecoderY,
+)
+from ..models.cevae_ss import (
+    EncoderZ as CEncoderZ,
+    ClassifierT as CClassifierT,
+    DecoderX as CDecoderX,
+    DecoderT as CDecoderT,
+    DecoderY as CDecoderY,
+)
 
 
 class M2VAE(nn.Module):


### PR DESCRIPTION
## Summary
- create default YAML configuration with sections for dataset, model hyperparameters, and training options
- implement `load()` helper using `yaml.safe_load`
- register PyYAML dependency
- fix broken imports and syntax

## Testing
- `python -m pip install -e .`
- `python -m compileall -q xtylearner`

------
https://chatgpt.com/codex/tasks/task_e_68689deb46788324ba61d6d1257f3c0f