### PR TITLE
Add basic tests and GitHub workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest -vv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ xtylearner-train = "xtylearner.scripts.train:main"
 [tool.setuptools]
 packages = ["xtylearner"]
 
+[tool.pytest.ini_options]
+addopts = "-vv"
+testpaths = ["tests"]
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,17 @@
+from xtylearner.data import load_toy_dataset, load_synthetic_dataset
+
+
+def test_load_toy_dataset_shapes():
+    ds = load_toy_dataset(n_samples=10, d_x=3, seed=1)
+    X, Y, T = ds.tensors
+    assert X.shape == (10, 3)
+    assert Y.shape == (10, 1)
+    assert T.shape == (10,)
+
+
+def test_load_synthetic_dataset_shapes():
+    ds = load_synthetic_dataset(n_samples=8, d_x=4, seed=2)
+    X, Y, T = ds.tensors
+    assert X.shape == (8, 4)
+    assert Y.shape == (8, 1)
+    assert T.shape == (8,)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,13 @@
+import pytest
+import torch
+from xtylearner.models import get_model, CycleDual
+
+
+def test_get_model_valid():
+    model = get_model("cycle_dual", d_x=2, d_y=1, k=2)
+    assert isinstance(model, CycleDual)
+
+
+def test_get_model_invalid():
+    with pytest.raises(ValueError):
+        get_model("unknown_model")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,16 @@
+import torch
+from torch.utils.data import DataLoader
+from xtylearner.data import load_toy_dataset
+from xtylearner.models import CycleDual
+from xtylearner.training import SupervisedTrainer
+
+
+def test_supervised_trainer_runs():
+    dataset = load_toy_dataset(n_samples=20, d_x=2, seed=0)
+    loader = DataLoader(dataset, batch_size=5)
+    model = CycleDual(d_x=2, d_y=1, k=2)
+    opt = torch.optim.SGD(model.parameters(), lr=0.01)
+    trainer = SupervisedTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)


### PR DESCRIPTION
## Summary
- add unit tests for model registry, dataset loaders, and trainer
- configure pytest via `pyproject.toml`
- add GitHub Actions workflow to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a7b26ff483248209939c49119d4b