### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,11 +13,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        pip install pytest
+        pip install pytest pytest-xdist
     - name: Run tests
       run: |
-        pytest -vv
+        pytest -vv -n auto


### PR DESCRIPTION
## Summary
- enable pip caching in CI
- use pytest-xdist to run tests in parallel

## Testing
- `pytest -vv -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6868aa068a9c8324b91249cc5cdc9d15