### PR TITLE
Improve README with install and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
 # XTYLearner
-Flexible implementations of various learners for joint learning or pre-treatment, treatment and post-treatment outcomes.
+
+Flexible implementations of various learners for joint learning of pre-treatment,
+treatment and post-treatment outcomes.
+
+## Installation
+
+XTYLearner requires Python 3.8 or newer. The package can be installed directly
+from source or, once published, from the Python Package Index.
+
+```bash
+# install from a local clone
+git clone <repository-url>
+cd XTYLearner
+pip install -e .
+
+# or install from PyPI when available
+pip install xtylearner
+```
+
+## API Overview
+
+### Loading Datasets
+
+Datasets are provided via :mod:`xtylearner.data`.  The convenience function
+:func:`xtylearner.data.get_dataset` returns a ``torch.utils.data.Dataset`` by
+name:
+
+```python
+from xtylearner.data import get_dataset
+
+dataset = get_dataset("toy", n_samples=100, d_x=2)
+```
+
+Individual loaders such as ``load_toy_dataset`` and ``load_synthetic_dataset``
+are also exported for direct use.
+
+### Creating Models
+
+Model architectures register themselves with the module
+:mod:`xtylearner.models`.  Instantiate a model through the registry using
+:func:`xtylearner.models.get_model`:
+
+```python
+from xtylearner.models import get_model
+
+model = get_model("m2_vae", d_x=2, d_y=1, k=2)
+```
+
+### Training Utilities
+
+Trainer classes live in :mod:`xtylearner.training` and operate on any model with
+a suitable ``loss`` method.  A typical workflow uses ``SupervisedTrainer``:
+
+```python
+from torch.utils.data import DataLoader
+from xtylearner.training import SupervisedTrainer
+
+loader = DataLoader(dataset, batch_size=32, shuffle=True)
+optimizer = torch.optim.Adam(model.parameters())
+trainer = SupervisedTrainer(model, optimizer, loader)
+trainer.fit(5)
+loss = trainer.evaluate(loader)
+```
+
+## Command Line Interface
+
+The package exposes a simple CLI for training defined in
+``xtylearner.scripts.train``.  After installation the entry point
+``xtylearner-train`` becomes available:
+
+```bash
+xtylearner-train --model m2_vae --dataset toy
+```
+
+This command loads the default configuration from
+``xtylearner/configs/default.yaml``.  A custom YAML config file may be supplied
+with ``--config`` to override any settings.


### PR DESCRIPTION
## Summary
- expand project description
- add installation instructions from source or PyPI
- document datasets, model registry and training utilities
- show minimal CLI invocation example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868aba798f48324b3a660b5e2cbf748