### PR TITLE
Add minimal losses and tests for all models

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,8 +1,14 @@
 import torch
 from torch.utils.data import DataLoader
 from xtylearner.data import load_toy_dataset
-from xtylearner.models import CycleDual
-from xtylearner.training import SupervisedTrainer
+from xtylearner.models import CycleDual, MixtureOfFlows, MultiTask
+from xtylearner.training import (
+    SupervisedTrainer,
+    M2VAE,
+    SS_CEVAE,
+    M2VAETrainer,
+    CEVAETrainer,
+)
 
 
 def test_supervised_trainer_runs():
@@ -11,6 +17,50 @@ def test_supervised_trainer_runs():
     model = CycleDual(d_x=2, d_y=1, k=2)
     opt = torch.optim.SGD(model.parameters(), lr=0.01)
     trainer = SupervisedTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_flow_model_runs():
+    dataset = load_toy_dataset(n_samples=20, d_x=2, seed=1)
+    loader = DataLoader(dataset, batch_size=5)
+    model = MixtureOfFlows(dim_x=2, dim_y=1, n_treat=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = SupervisedTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_multitask_model_runs():
+    dataset = load_toy_dataset(n_samples=20, d_x=2, seed=2)
+    loader = DataLoader(dataset, batch_size=5)
+    model = MultiTask(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = SupervisedTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_m2vae_trainer_runs():
+    dataset = load_toy_dataset(n_samples=20, d_x=2, seed=3)
+    loader = DataLoader(dataset, batch_size=5)
+    model = M2VAE(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = M2VAETrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_cevae_trainer_runs():
+    dataset = load_toy_dataset(n_samples=20, d_x=2, seed=4)
+    loader = DataLoader(dataset, batch_size=5)
+    model = SS_CEVAE(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = CEVAETrainer(model, opt, loader)
     trainer.fit(1)
     loss = trainer.evaluate(loader)
     assert isinstance(loss, float)

--- a/xtylearner/models/multitask_selftrain.py
+++ b/xtylearner/models/multitask_selftrain.py
@@ -57,6 +57,16 @@ class MultiTask(nn.Module):
         X_hat = self.head_X(torch.cat([Y, T_onehot], -1))
         return Y_hat, logits_T, X_hat
 
+    def loss(self, X, Y, T_obs):
+        """Simple supervised loss used for unit tests."""
+        T_1h = torch.nn.functional.one_hot(T_obs, self.k).float()
+        Y_hat, logits_T, X_hat = self.forward(X, Y, T_1h)
+        mse = nn.functional.mse_loss
+        L_y = mse(Y_hat, Y)
+        L_x = mse(X_hat, X)
+        L_t = nn.functional.cross_entropy(logits_T, T_obs)
+        return L_y + L_x + L_t
+
 
 class DataWrapper(torch.utils.data.Dataset):
     def __init__(self, X, Y, T):


### PR DESCRIPTION
## Summary
- implement a small `loss` function for `MultiTask`
- exercise every model type in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b4e45a748324b367683bff3d6692