### PR TITLE
Add mixed synthetic dataset

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,4 +1,8 @@
-from xtylearner.data import load_toy_dataset, load_synthetic_dataset
+from xtylearner.data import (
+    load_toy_dataset,
+    load_synthetic_dataset,
+    load_mixed_synthetic_dataset,
+)
 
 
 def test_load_toy_dataset_shapes():
@@ -15,3 +19,13 @@ def test_load_synthetic_dataset_shapes():
     assert X.shape == (8, 4)
     assert Y.shape == (8, 1)
     assert T.shape == (8,)
+
+
+def test_load_mixed_synthetic_dataset_shapes():
+    ds = load_mixed_synthetic_dataset(n_samples=10, d_x=3, seed=3, label_ratio=0.6)
+    X, Y, T = ds.tensors
+    assert X.shape == (10, 3)
+    assert Y.shape == (10, 1)
+    assert T.shape == (10,)
+    assert (T == -1).sum() > 0
+    assert (T >= 0).sum() > 0

--- a/xtylearner/data/__init__.py
+++ b/xtylearner/data/__init__.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict
 
 from .toy_dataset import load_toy_dataset
 from .synthetic_dataset import load_synthetic_dataset
+from .mixed_synthetic_dataset import load_mixed_synthetic_dataset
 from .ihdp_dataset import load_ihdp
 from .twins_dataset import load_twins
 
@@ -13,6 +14,7 @@ from .twins_dataset import load_twins
 _DATASETS: Dict[str, Callable[..., object]] = {
     "toy": load_toy_dataset,
     "synthetic": load_synthetic_dataset,
+    "synthetic_mixed": load_mixed_synthetic_dataset,
     "ihdp": load_ihdp,
     "twins": load_twins,
 }
@@ -45,6 +47,7 @@ __all__ = [
     "get_dataset",
     "load_toy_dataset",
     "load_synthetic_dataset",
+    "load_mixed_synthetic_dataset",
     "load_ihdp",
     "load_twins",
 ]

--- a/xtylearner/data/mixed_synthetic_dataset.py
+++ b/xtylearner/data/mixed_synthetic_dataset.py
@@ -1,0 +1,39 @@
+"""Synthetic dataset with a mix of labelled and unlabelled samples."""
+
+from __future__ import annotations
+
+import numpy as np
+from torch.utils.data import TensorDataset
+
+from .synthetic_dataset import load_synthetic_dataset
+
+
+def load_mixed_synthetic_dataset(
+    n_samples: int = 1000,
+    d_x: int = 5,
+    seed: int = 0,
+    label_ratio: float = 0.5,
+) -> TensorDataset:
+    """Generate a synthetic dataset with partially missing treatments.
+
+    Parameters
+    ----------
+    label_ratio:
+        Fraction of samples with observed treatment labels.
+
+    Returns
+    -------
+    TensorDataset
+        Dataset ``(X, Y, T_obs)`` where unobserved ``T`` entries are ``-1``.
+    """
+
+    base = load_synthetic_dataset(n_samples=n_samples, d_x=d_x, seed=seed)
+    X, Y, T = base.tensors
+    rng = np.random.default_rng(seed + 1)
+    unlab = rng.random(n_samples) >= label_ratio
+    T_obs = T.clone()
+    T_obs[unlab] = -1
+    return TensorDataset(X, Y, T_obs)
+
+
+__all__ = ["load_mixed_synthetic_dataset"]


### PR DESCRIPTION
## Summary
- support semi-supervised experiments with a mixed synthetic dataset
- wire new dataset into data registry
- test dataset loader

## Testing
- `pre-commit run --files xtylearner/data/mixed_synthetic_dataset.py xtylearner/data/__init__.py tests/test_datasets.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b90e1070832489b4d23986cafd1a