### PR TITLE
Add support for missing treatments

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,6 +1,6 @@
 import torch
 from torch.utils.data import DataLoader
-from xtylearner.data import load_toy_dataset
+from xtylearner.data import load_toy_dataset, load_mixed_synthetic_dataset
 from xtylearner.models import CycleDual, MixtureOfFlows, MultiTask
 from xtylearner.training import (
     SupervisedTrainer,
@@ -57,6 +57,28 @@ def test_m2vae_trainer_runs():
 
 def test_cevae_trainer_runs():
     dataset = load_toy_dataset(n_samples=20, d_x=2, seed=4)
+    loader = DataLoader(dataset, batch_size=5)
+    model = SS_CEVAE(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = CEVAETrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_supervised_trainer_mixed_dataset():
+    dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=5, label_ratio=0.5)
+    loader = DataLoader(dataset, batch_size=5)
+    model = CycleDual(d_x=2, d_y=1, k=2)
+    opt = torch.optim.SGD(model.parameters(), lr=0.01)
+    trainer = SupervisedTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_cevae_trainer_mixed_dataset():
+    dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=6, label_ratio=0.5)
     loader = DataLoader(dataset, batch_size=5)
     model = SS_CEVAE(d_x=2, d_y=1, k=2)
     opt = torch.optim.Adam(model.parameters(), lr=0.01)

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -150,7 +150,12 @@ class GenerativeTrainer(BaseTrainer):
     """Trainer for generative models using an ELBO objective."""
 
     def step(self, batch: Iterable[torch.Tensor]) -> torch.Tensor:
-        x, y, t = (b.to(self.device) for b in batch)
+        data = [b.to(self.device) for b in batch]
+        if len(data) == 2:
+            x, y = data
+            t = torch.full((x.size(0),), -1, dtype=torch.long, device=self.device)
+        else:
+            x, y, t = data
         return self.model.elbo(x, y, t)
 
     def fit(self, num_epochs: int) -> None:

--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -12,6 +12,10 @@ class SupervisedTrainer(BaseTrainer):
 
     def step(self, batch: Iterable[torch.Tensor]) -> torch.Tensor:
         inputs = [b.to(self.device) for b in batch]
+        if len(inputs) == 2:
+            x, y = inputs
+            t_obs = torch.full((x.size(0),), -1, dtype=torch.long, device=self.device)
+            inputs = [x, y, t_obs]
         if hasattr(self.model, "loss"):
             return self.model.loss(*inputs)
         # fall back to assuming the model itself returns a loss


### PR DESCRIPTION
## Summary
- allow training batches without treatment labels by creating a default ``-1`` label
- update generative trainer accordingly
- test trainers with mixed synthetic dataset

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868bcc4dd98832480422edbd116d3e3