### PR TITLE
Improve README with missing T docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ trainer.fit(5)
 loss = trainer.evaluate(loader)
 ```
 
+### Handling Missing Treatment Labels
+
+Datasets may contain unobserved treatments denoted by ``-1`` in the
+``T`` tensor (see :func:`xtylearner.data.load_mixed_synthetic_dataset`).
+All trainers automatically separate labelled and unlabelled rows based on
+this value.  When only ``(X, Y)`` pairs are provided, the trainer will
+internally set ``T`` to ``-1`` for every sample.
+
+Models such as ``CycleDual`` and ``MixtureOfFlows`` impute or marginalise over
+the missing labels, while generative trainers like ``M2VAETrainer`` and
+``CEVAETrainer`` optimise a semi-supervised objective using both labelled and
+unlabelled data.  A typical workflow is:
+
+```python
+from xtylearner.data import load_mixed_synthetic_dataset
+from xtylearner.training import M2VAETrainer
+
+dataset = load_mixed_synthetic_dataset(n_samples=100, label_ratio=0.3)
+loader = DataLoader(dataset, batch_size=32, shuffle=True)
+model = get_model("m2_vae", d_x=2, d_y=1, k=2)
+optimizer = torch.optim.Adam(model.parameters())
+trainer = M2VAETrainer(model, optimizer, loader)
+trainer.fit(5)
+```
+
 ## Command Line Interface
 
 The package exposes a simple CLI for training defined in


### PR DESCRIPTION
## Summary
- document how to train when treatments are missing

## Testing
- `pre-commit run --files README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868bfbf9b6083249490c633b41e4cc1