### PR TITLE
Add tabular dataset loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "scikit-learn",
     "numpy",
     "nflows",
-    "pyyaml"
+    "pyyaml",
+    "pandas"
 ]
 
 [project.scripts]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,11 @@
+import numpy as np
+import pandas as pd
+
 from xtylearner.data import (
     load_toy_dataset,
     load_synthetic_dataset,
     load_mixed_synthetic_dataset,
+    load_tabular_dataset,
 )
 
 
@@ -29,3 +33,46 @@ def test_load_mixed_synthetic_dataset_shapes():
     assert T.shape == (10,)
     assert (T == -1).sum() > 0
     assert (T >= 0).sum() > 0
+
+
+def _create_frame(n: int = 5):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "x1": rng.normal(size=n).astype(np.float32),
+            "x2": rng.normal(size=n).astype(np.float32),
+            "outcome": rng.normal(size=n).astype(np.float32),
+            "treatment": rng.integers(0, 2, size=n).astype(np.int64),
+        }
+    )
+    return df
+
+
+def test_load_tabular_from_dataframe():
+    df = _create_frame(6)
+    ds = load_tabular_dataset(df)
+    X, Y, T = ds.tensors
+    assert X.shape == (6, 2)
+    assert Y.shape == (6, 1)
+    assert T.shape == (6,)
+
+
+def test_load_tabular_from_csv(tmp_path):
+    df = _create_frame(4)
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+    ds = load_tabular_dataset(path)
+    X, Y, T = ds.tensors
+    assert X.shape == (4, 2)
+    assert Y.shape == (4, 1)
+    assert T.shape == (4,)
+
+
+def test_load_tabular_from_array():
+    df = _create_frame(3)
+    arr = df.to_numpy()
+    ds = load_tabular_dataset(arr)
+    X, Y, T = ds.tensors
+    assert X.shape == (3, 2)
+    assert Y.shape == (3, 1)
+    assert T.shape == (3,)

--- a/xtylearner/data/__init__.py
+++ b/xtylearner/data/__init__.py
@@ -9,6 +9,7 @@ from .synthetic_dataset import load_synthetic_dataset
 from .mixed_synthetic_dataset import load_mixed_synthetic_dataset
 from .ihdp_dataset import load_ihdp
 from .twins_dataset import load_twins
+from .tabular_dataset import load_tabular_dataset
 
 
 _DATASETS: Dict[str, Callable[..., object]] = {
@@ -50,4 +51,5 @@ __all__ = [
     "load_mixed_synthetic_dataset",
     "load_ihdp",
     "load_twins",
+    "load_tabular_dataset",
 ]

--- a/xtylearner/data/tabular_dataset.py
+++ b/xtylearner/data/tabular_dataset.py
@@ -1,0 +1,70 @@
+"""Utility to convert generic tabular data to a ``TensorDataset``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import TensorDataset
+
+
+def load_tabular_dataset(
+    data: Union[str, Path, np.ndarray, pd.DataFrame],
+    outcome_col: str = "outcome",
+    treatment_col: str = "treatment",
+) -> TensorDataset:
+    """Convert CSV, NumPy array or ``pandas.DataFrame`` into a ``TensorDataset``.
+
+    Parameters
+    ----------
+    data:
+        Path to a CSV file, a ``numpy.ndarray`` with columns ``X``/``Y``/``T`` or
+        a ``pandas.DataFrame`` containing the same information.
+    outcome_col:
+        Name of the outcome column for ``DataFrame``/CSV inputs.
+    treatment_col:
+        Name of the treatment column for ``DataFrame``/CSV inputs.
+
+    Returns
+    -------
+    TensorDataset
+        Dataset of ``(X, Y, T)`` tensors.
+    """
+
+    if isinstance(data, (str, Path)):
+        df = pd.read_csv(data)
+    elif isinstance(data, pd.DataFrame):
+        df = data.copy()
+    elif isinstance(data, np.ndarray):
+        if data.ndim != 2 or data.shape[1] < 3:
+            raise ValueError("NumPy array must have shape (n, d_x + 2)")
+        X = data[:, :-2].astype(np.float32)
+        Y = data[:, -2].astype(np.float32)
+        T = data[:, -1].astype(np.int64)
+        return TensorDataset(
+            torch.from_numpy(X),
+            torch.from_numpy(Y).unsqueeze(-1),
+            torch.from_numpy(T),
+        )
+    else:
+        raise TypeError("Unsupported data type for load_tabular_dataset")
+
+    if outcome_col not in df.columns or treatment_col not in df.columns:
+        raise ValueError("Missing outcome or treatment columns")
+
+    covariate_cols = [c for c in df.columns if c not in {outcome_col, treatment_col}]
+    X = df[covariate_cols].to_numpy(dtype=np.float32)
+    Y = df[outcome_col].to_numpy(dtype=np.float32)
+    T = df[treatment_col].to_numpy(dtype=np.int64)
+
+    return TensorDataset(
+        torch.from_numpy(X),
+        torch.from_numpy(Y).reshape(-1, 1),
+        torch.from_numpy(T),
+    )
+
+
+__all__ = ["load_tabular_dataset"]


### PR DESCRIPTION
## Summary
- add handler for tabular datasets from CSV, NumPy arrays and pandas DataFrames
- expose `load_tabular_dataset` in the data package
- include pandas as dependency
- test data loader functionality

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c28a6c008324b43a5a95e4f28581