### PR TITLE
Extend tabular dataset loader

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -76,3 +76,34 @@ def test_load_tabular_from_array():
     assert X.shape == (3, 2)
     assert Y.shape == (3, 1)
     assert T.shape == (3,)
+
+
+def test_load_tabular_multiple_outcomes_dataframe():
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "x1": rng.normal(size=5).astype(np.float32),
+            "x2": rng.normal(size=5).astype(np.float32),
+            "y1": rng.normal(size=5).astype(np.float32),
+            "y2": rng.normal(size=5).astype(np.float32),
+            "t": rng.integers(0, 2, size=5).astype(np.int64),
+        }
+    )
+    ds = load_tabular_dataset(df, outcome_col=["y1", "y2"], treatment_col="t")
+    X, Y, T = ds.tensors
+    assert X.shape == (5, 2)
+    assert Y.shape == (5, 2)
+    assert T.shape == (5,)
+
+
+def test_load_tabular_multiple_outcomes_array():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(4, 2)).astype(np.float32)
+    Y = rng.normal(size=(4, 2)).astype(np.float32)
+    T = rng.integers(0, 2, size=(4, 1)).astype(np.int64)
+    arr = np.concatenate([X, Y, T], axis=1)
+    ds = load_tabular_dataset(arr, outcome_col=2)
+    X_t, Y_t, T_t = ds.tensors
+    assert X_t.shape == (4, 2)
+    assert Y_t.shape == (4, 2)
+    assert T_t.shape == (4,)

--- a/xtylearner/data/tabular_dataset.py
+++ b/xtylearner/data/tabular_dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
+from typing import Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,7 @@ from torch.utils.data import TensorDataset
 
 def load_tabular_dataset(
     data: Union[str, Path, np.ndarray, pd.DataFrame],
-    outcome_col: str = "outcome",
+    outcome_col: Union[str, Sequence[str], int] = "outcome",
     treatment_col: str = "treatment",
 ) -> TensorDataset:
     """Convert CSV, NumPy array or ``pandas.DataFrame`` into a ``TensorDataset``.
@@ -24,7 +24,11 @@ def load_tabular_dataset(
         Path to a CSV file, a ``numpy.ndarray`` with columns ``X``/``Y``/``T`` or
         a ``pandas.DataFrame`` containing the same information.
     outcome_col:
-        Name of the outcome column for ``DataFrame``/CSV inputs.
+        Name of the outcome column for ``DataFrame``/CSV inputs.  Can be a
+        sequence of names if multiple outcome variables are present.  When
+        ``data`` is a ``numpy.ndarray`` this argument may also be an integer
+        specifying the number of outcome columns.  In this case the outcome
+        columns are assumed to appear immediately before the treatment column.
     treatment_col:
         Name of the treatment column for ``DataFrame``/CSV inputs.
 
@@ -39,30 +43,49 @@ def load_tabular_dataset(
     elif isinstance(data, pd.DataFrame):
         df = data.copy()
     elif isinstance(data, np.ndarray):
-        if data.ndim != 2 or data.shape[1] < 3:
-            raise ValueError("NumPy array must have shape (n, d_x + 2)")
-        X = data[:, :-2].astype(np.float32)
-        Y = data[:, -2].astype(np.float32)
+        if isinstance(outcome_col, str):
+            n_outcomes = 1
+        elif isinstance(outcome_col, int):
+            n_outcomes = outcome_col
+        else:
+            n_outcomes = len(outcome_col)
+
+        if data.ndim != 2 or data.shape[1] < n_outcomes + 2:
+            raise ValueError("NumPy array must have shape (n, d_x + n_outcomes + 1)")
+
+        X = data[:, : -(n_outcomes + 1)].astype(np.float32)
+        Y = data[:, -(n_outcomes + 1) : -1].astype(np.float32)
         T = data[:, -1].astype(np.int64)
         return TensorDataset(
             torch.from_numpy(X),
-            torch.from_numpy(Y).unsqueeze(-1),
+            torch.from_numpy(Y).reshape(-1, n_outcomes),
             torch.from_numpy(T),
         )
     else:
         raise TypeError("Unsupported data type for load_tabular_dataset")
 
-    if outcome_col not in df.columns or treatment_col not in df.columns:
+    outcome_cols: Sequence[str]
+    if isinstance(outcome_col, str):
+        outcome_cols = [outcome_col]
+    elif isinstance(outcome_col, int):  # type: ignore[unreachable]
+        raise TypeError("Numeric outcome_col only valid for NumPy array inputs")
+    else:
+        outcome_cols = list(outcome_col)
+
+    missing = set(outcome_cols + [treatment_col]) - set(df.columns)
+    if missing:
         raise ValueError("Missing outcome or treatment columns")
 
-    covariate_cols = [c for c in df.columns if c not in {outcome_col, treatment_col}]
+    covariate_cols = [
+        c for c in df.columns if c not in set(outcome_cols + [treatment_col])
+    ]
     X = df[covariate_cols].to_numpy(dtype=np.float32)
-    Y = df[outcome_col].to_numpy(dtype=np.float32)
+    Y = df[outcome_cols].to_numpy(dtype=np.float32)
     T = df[treatment_col].to_numpy(dtype=np.int64)
 
     return TensorDataset(
         torch.from_numpy(X),
-        torch.from_numpy(Y).reshape(-1, 1),
+        torch.from_numpy(Y).reshape(-1, len(outcome_cols)),
         torch.from_numpy(T),
     )
 


### PR DESCRIPTION
## Summary
- support multiple outcomes in `load_tabular_dataset`
- add tests for multi-outcome datasets

## Testing
- `ruff check --fix xtylearner/data/tabular_dataset.py tests/test_datasets.py`
- `black xtylearner/data/tabular_dataset.py tests/test_datasets.py`
- `ruff check xtylearner/data/tabular_dataset.py tests/test_datasets.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c561d15883249944223a1a634950