### PR TITLE
Refactor models to share configurable MLP

### DIFF
--- a/xtylearner/models/cycle_dual.py
+++ b/xtylearner/models/cycle_dual.py
@@ -9,18 +9,9 @@ import torch
 import torch.nn as nn
 from torch.nn.functional import one_hot, cross_entropy
 
+from .layers import make_mlp
+
 from .registry import register_model
-
-
-# ---------- tiny helper MLP ---------------------------------------------
-def mlp(in_dim, out_dim, hidden=128):
-    return nn.Sequential(
-        nn.Linear(in_dim, hidden),
-        nn.ReLU(),
-        nn.Linear(hidden, hidden),
-        nn.ReLU(),
-        nn.Linear(hidden, out_dim),
-    )
 
 
 # ---------- dual-network module -----------------------------------------
@@ -35,9 +26,9 @@ class CycleDual(nn.Module):
     def __init__(self, d_x, d_y, k):
         super().__init__()
         self.k = k
-        self.G_Y = mlp(d_x + k, d_y)
-        self.G_X = mlp(k + d_y, d_x)
-        self.C = mlp(d_x + d_y, k)
+        self.G_Y = make_mlp([d_x + k, 128, 128, d_y])
+        self.G_X = make_mlp([k + d_y, 128, 128, d_x])
+        self.C = make_mlp([d_x + d_y, 128, 128, k])
 
     # ------------------------------------------------------------------
     def loss(self, X, Y, T_obs, λ_sup=1.0, λ_cyc=1.0, λ_ent=0.1):

--- a/xtylearner/models/layers.py
+++ b/xtylearner/models/layers.py
@@ -1,0 +1,22 @@
+import torch.nn as nn
+from typing import Sequence, Callable
+
+
+def make_mlp(
+    dims: Sequence[int], activation: Callable[[], nn.Module] = nn.ReLU
+) -> nn.Sequential:
+    """Construct a simple feedforward neural network.
+
+    Parameters
+    ----------
+    dims : Sequence[int]
+        List of layer dimensions ``[in_dim, hidden1, ..., out_dim]``.
+    activation : Callable[[], nn.Module], optional
+        Activation constructor inserted between linear layers. Defaults to ``nn.ReLU``.
+    """
+    layers = []
+    for i in range(len(dims) - 1):
+        layers.append(nn.Linear(dims[i], dims[i + 1]))
+        if i < len(dims) - 2:
+            layers.append(activation())
+    return nn.Sequential(*layers)

--- a/xtylearner/models/multitask_selftrain.py
+++ b/xtylearner/models/multitask_selftrain.py
@@ -16,19 +16,13 @@
 import torch
 import torch.nn as nn
 
+from .layers import make_mlp
+
 from .registry import register_model
 
 
 # ------------------------------------------------------------
 # shared encoder for any vector input -------------------------
-def mlp(in_dim, out_dim, hidden=128):
-    return nn.Sequential(
-        nn.Linear(in_dim, hidden),
-        nn.ReLU(),
-        nn.Linear(hidden, hidden),
-        nn.ReLU(),
-        nn.Linear(hidden, out_dim),
-    )
 
 
 @register_model("multitask")
@@ -43,11 +37,11 @@ class MultiTask(nn.Module):
     def __init__(self, d_x, d_y, k, h_dim=128):
         super().__init__()
         self.k = k
-        self.h = mlp(d_x, h_dim)
+        self.h = make_mlp([d_x, 128, 128, h_dim])
 
-        self.head_Y = mlp(h_dim + k, d_y)  # predict Y
-        self.head_T = mlp(d_x + d_y, k)  # predict T
-        self.head_X = mlp(d_y + k, d_x)  # reconstruct X
+        self.head_Y = make_mlp([h_dim + k, 128, 128, d_y])  # predict Y
+        self.head_T = make_mlp([d_x + d_y, 128, 128, k])  # predict T
+        self.head_X = make_mlp([d_y + k, 128, 128, d_x])  # reconstruct X
 
     # --------------------------------------------------------
     def forward(self, X, Y, T_onehot):


### PR DESCRIPTION
## Summary
- add `make_mlp` helper in `xtylearner/models/layers.py`
- refactor model components to use the shared MLP builder

## Testing
- `pre-commit run --files xtylearner/models/cycle_dual.py xtylearner/models/m2_vae.py xtylearner/models/cevae_ss.py xtylearner/models/multitask_selftrain.py xtylearner/models/layers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c8b665cc832487b288c52129bd59