### PR TITLE
Add configurable dropout and normalization to MLP

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,35 @@
+import pytest
+import torch.nn as nn
+
+from xtylearner.models.layers import make_mlp
+
+
+def test_make_mlp_default():
+    mlp = make_mlp([2, 3, 1])
+    assert len(mlp) == 3
+    assert isinstance(mlp[0], nn.Linear)
+    assert isinstance(mlp[1], nn.ReLU)
+    assert isinstance(mlp[2], nn.Linear)
+
+
+def test_make_mlp_with_norm_and_dropout():
+    mlp = make_mlp(
+        [2, 3, 1], activation=nn.Tanh, dropout=0.2, norm_layer=nn.BatchNorm1d
+    )
+    assert isinstance(mlp[0], nn.Linear)
+    assert isinstance(mlp[1], nn.BatchNorm1d)
+    assert isinstance(mlp[2], nn.Tanh)
+    assert isinstance(mlp[3], nn.Dropout)
+    assert isinstance(mlp[4], nn.Linear)
+
+
+def test_make_mlp_dropout_sequence():
+    mlp = make_mlp([2, 3, 4, 1], dropout=[0.1, 0.3])
+    layers = list(mlp)
+    assert isinstance(layers[2], nn.Dropout)
+    assert isinstance(layers[5], nn.Dropout)
+
+
+def test_make_mlp_dropout_mismatch():
+    with pytest.raises(ValueError):
+        make_mlp([2, 3, 1], dropout=[0.1, 0.2])

--- a/xtylearner/models/layers.py
+++ b/xtylearner/models/layers.py
@@ -1,9 +1,14 @@
+from typing import Callable, Sequence, Iterable, Optional
+
 import torch.nn as nn
-from typing import Sequence, Callable
 
 
 def make_mlp(
-    dims: Sequence[int], activation: Callable[[], nn.Module] = nn.ReLU
+    dims: Sequence[int],
+    activation: Callable[[], nn.Module] = nn.ReLU,
+    *,
+    dropout: Optional[Iterable[float]] | float | None = None,
+    norm_layer: Optional[Callable[[int], nn.Module]] = None,
 ) -> nn.Sequential:
     """Construct a simple feedforward neural network.
 
@@ -13,10 +18,35 @@ def make_mlp(
         List of layer dimensions ``[in_dim, hidden1, ..., out_dim]``.
     activation : Callable[[], nn.Module], optional
         Activation constructor inserted between linear layers. Defaults to ``nn.ReLU``.
+    dropout : float | Iterable[float] | None, optional
+        Dropout probability after activation for each hidden layer. If a single
+        float is provided it is used for all hidden layers. ``None`` disables
+        dropout.
+    norm_layer : Callable[[int], nn.Module] | None, optional
+        Normalisation layer constructor applied to each hidden layer. The integer
+        argument corresponds to the size of the current layer.
     """
+
+    n_layers = len(dims) - 1
+    if isinstance(dropout, Iterable) and not isinstance(dropout, (str, bytes)):
+        dropouts = list(dropout)
+        if len(dropouts) != n_layers - 1:
+            raise ValueError("dropout iterable must match number of hidden layers")
+    elif dropout is None:
+        dropouts = [None] * (n_layers - 1)
+    else:
+        dropouts = [float(dropout)] * (n_layers - 1)
+
     layers = []
-    for i in range(len(dims) - 1):
-        layers.append(nn.Linear(dims[i], dims[i + 1]))
-        if i < len(dims) - 2:
+    for i in range(n_layers):
+        in_dim, out_dim = dims[i], dims[i + 1]
+        layers.append(nn.Linear(in_dim, out_dim))
+        if i < n_layers - 1:
+            if norm_layer is not None:
+                layers.append(norm_layer(out_dim))
             layers.append(activation())
+            p = dropouts[i]
+            if p is not None and p > 0:
+                layers.append(nn.Dropout(p))
+
     return nn.Sequential(*layers)


### PR DESCRIPTION
## Summary
- make `make_mlp` more flexible by supporting dropout and arbitrary normalisation layers
- add tests for the new functionality

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868cd1a13088324adda660fbad8c0f4