### PR TITLE
Expose MLP options in model constructors

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,10 +1,26 @@
 import pytest
+import torch.nn as nn
 from xtylearner.models import get_model, CycleDual
 
 
 def test_get_model_valid():
     model = get_model("cycle_dual", d_x=2, d_y=1, k=2)
     assert isinstance(model, CycleDual)
+
+
+def test_get_model_with_mlp_args():
+    model = get_model(
+        "cycle_dual",
+        d_x=2,
+        d_y=1,
+        k=2,
+        hidden_dims=[16],
+        dropout=0.1,
+    )
+    layers = list(model.G_Y)
+    assert isinstance(layers[1], nn.ReLU)
+    assert any(isinstance(l, nn.Dropout) for l in layers)
+    assert layers[0].out_features == 16
 
 
 def test_get_model_invalid():

--- a/xtylearner/models/cevae_ss.py
+++ b/xtylearner/models/cevae_ss.py
@@ -12,10 +12,32 @@ from .layers import make_mlp
 
 
 class EncoderZ(nn.Module):  # q(z | x,t,y)
-    def __init__(self, d_x, k, d_y, d_z):
+    def __init__(
+        self,
+        d_x,
+        k,
+        d_y,
+        d_z,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.mu = make_mlp([d_x + k + d_y, 128, 128, d_z])
-        self.log = make_mlp([d_x + k + d_y, 128, 128, d_z])
+        dims = [d_x + k + d_y, *hidden_dims, d_z]
+        self.mu = make_mlp(
+            dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.log = make_mlp(
+            dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x, t_1h, y):
         h = torch.cat([x, t_1h, y], -1)
@@ -26,36 +48,96 @@ class EncoderZ(nn.Module):  # q(z | x,t,y)
 
 
 class ClassifierT(nn.Module):  # q(t | x,y)
-    def __init__(self, d_x, d_y, k):
+    def __init__(
+        self,
+        d_x,
+        d_y,
+        k,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_x + d_y, 128, 128, k])
+        self.net = make_mlp(
+            [d_x + d_y, *hidden_dims, k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x, y):  # logits
         return self.net(torch.cat([x, y], -1))
 
 
 class DecoderX(nn.Module):  # p(x | z)
-    def __init__(self, d_z, d_x):
+    def __init__(
+        self,
+        d_z,
+        d_x,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_z, 128, 128, d_x])
+        self.net = make_mlp(
+            [d_z, *hidden_dims, d_x],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, z):  # Gaussian mean
         return self.net(z)
 
 
 class DecoderT(nn.Module):  # p(t | z,x)
-    def __init__(self, d_z, d_x, k):
+    def __init__(
+        self,
+        d_z,
+        d_x,
+        k,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_z + d_x, 128, 128, k])
+        self.net = make_mlp(
+            [d_z + d_x, *hidden_dims, k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, z, x):  # logits
         return self.net(torch.cat([z, x], -1))
 
 
 class DecoderY(nn.Module):  # p(y | z,x,t)
-    def __init__(self, d_z, d_x, k, d_y):
+    def __init__(
+        self,
+        d_z,
+        d_x,
+        k,
+        d_y,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_z + d_x + k, 128, 128, d_y])
+        self.net = make_mlp(
+            [d_z + d_x + k, *hidden_dims, d_y],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, z, x, t_1h):  # mean
         return self.net(torch.cat([z, x, t_1h], -1))

--- a/xtylearner/models/cycle_dual.py
+++ b/xtylearner/models/cycle_dual.py
@@ -23,12 +23,37 @@ class CycleDual(nn.Module):
     C   : (X ⊕ Y) → logits(T)
     """
 
-    def __init__(self, d_x, d_y, k):
+    def __init__(
+        self,
+        d_x,
+        d_y,
+        k,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
         self.k = k
-        self.G_Y = make_mlp([d_x + k, 128, 128, d_y])
-        self.G_X = make_mlp([k + d_y, 128, 128, d_x])
-        self.C = make_mlp([d_x + d_y, 128, 128, k])
+        self.G_Y = make_mlp(
+            [d_x + k, *hidden_dims, d_y],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.G_X = make_mlp(
+            [k + d_y, *hidden_dims, d_x],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.C = make_mlp(
+            [d_x + d_y, *hidden_dims, k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     # ------------------------------------------------------------------
     def loss(self, X, Y, T_obs, λ_sup=1.0, λ_cyc=1.0, λ_ent=0.1):

--- a/xtylearner/models/m2_vae.py
+++ b/xtylearner/models/m2_vae.py
@@ -11,10 +11,31 @@ from .layers import make_mlp
 # ------------------------------------------------------------
 # 2. the model components
 class EncoderZ(nn.Module):  # q_phi(z | x,t)
-    def __init__(self, d_x, k, d_z):
+    def __init__(
+        self,
+        d_x,
+        k,
+        d_z,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net_mu = make_mlp([d_x + k, 128, 128, d_z])
-        self.net_log = make_mlp([d_x + k, 128, 128, d_z])
+        dims = [d_x + k, *hidden_dims, d_z]
+        self.net_mu = make_mlp(
+            dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.net_log = make_mlp(
+            dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x, t_onehot):
         h = torch.cat([x, t_onehot], -1)
@@ -26,36 +47,96 @@ class EncoderZ(nn.Module):  # q_phi(z | x,t)
 
 
 class ClassifierT(nn.Module):  # q_phi(t | x,y)
-    def __init__(self, d_x, d_y, k):
+    def __init__(
+        self,
+        d_x,
+        d_y,
+        k,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_x + d_y, 128, 128, k])
+        self.net = make_mlp(
+            [d_x + d_y, *hidden_dims, k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x, y):
         return self.net(torch.cat([x, y], -1))  # logits
 
 
 class DecoderX(nn.Module):  # p_theta(x | z)
-    def __init__(self, d_z, d_x):
+    def __init__(
+        self,
+        d_z,
+        d_x,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_z, 128, 128, d_x])
+        self.net = make_mlp(
+            [d_z, *hidden_dims, d_x],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, z):
         return self.net(z)  # Gaussian mean
 
 
 class DecoderT(nn.Module):  # p_theta(t | x,z)
-    def __init__(self, d_x, d_z, k):
+    def __init__(
+        self,
+        d_x,
+        d_z,
+        k,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_x + d_z, 128, 128, k])
+        self.net = make_mlp(
+            [d_x + d_z, *hidden_dims, k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x, z):
         return self.net(torch.cat([x, z], -1))  # logits
 
 
 class DecoderY(nn.Module):  # p_theta(y | x,t,z)
-    def __init__(self, d_x, k, d_z, d_y):
+    def __init__(
+        self,
+        d_x,
+        k,
+        d_z,
+        d_y,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.net = make_mlp([d_x + k + d_z, 128, 128, d_y])
+        self.net = make_mlp(
+            [d_x + k + d_z, *hidden_dims, d_y],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x, t_onehot, z):
         return self.net(torch.cat([x, t_onehot, z], -1))  # mean

--- a/xtylearner/models/multitask_selftrain.py
+++ b/xtylearner/models/multitask_selftrain.py
@@ -34,14 +34,45 @@ class MultiTask(nn.Module):
     f_X(Y,T)        : inverse regressor
     """
 
-    def __init__(self, d_x, d_y, k, h_dim=128):
+    def __init__(
+        self,
+        d_x,
+        d_y,
+        k,
+        h_dim=128,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
         self.k = k
-        self.h = make_mlp([d_x, 128, 128, h_dim])
+        self.h = make_mlp(
+            [d_x, *hidden_dims, h_dim],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
-        self.head_Y = make_mlp([h_dim + k, 128, 128, d_y])  # predict Y
-        self.head_T = make_mlp([d_x + d_y, 128, 128, k])  # predict T
-        self.head_X = make_mlp([d_y + k, 128, 128, d_x])  # reconstruct X
+        self.head_Y = make_mlp(
+            [h_dim + k, *hidden_dims, d_y],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )  # predict Y
+        self.head_T = make_mlp(
+            [d_x + d_y, *hidden_dims, k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )  # predict T
+        self.head_X = make_mlp(
+            [d_y + k, *hidden_dims, d_x],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )  # reconstruct X
 
     # --------------------------------------------------------
     def forward(self, X, Y, T_onehot):

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -27,13 +27,65 @@ from ..models.cevae_ss import (
 class M2VAE(nn.Module):
     """Simplified implementation of the M2 model."""
 
-    def __init__(self, d_x: int, d_y: int, k: int, d_z: int = 16, tau: float = 0.5):
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k: int,
+        d_z: int = 16,
+        tau: float = 0.5,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.enc_z = M2EncoderZ(d_x, k, d_z)
-        self.cls_t = M2ClassifierT(d_x, d_y, k)
-        self.dec_x = M2DecoderX(d_z, d_x)
-        self.dec_t = M2DecoderT(d_x, d_z, k)
-        self.dec_y = M2DecoderY(d_x, k, d_z, d_y)
+        self.enc_z = M2EncoderZ(
+            d_x,
+            k,
+            d_z,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.cls_t = M2ClassifierT(
+            d_x,
+            d_y,
+            k,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.dec_x = M2DecoderX(
+            d_z,
+            d_x,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.dec_t = M2DecoderT(
+            d_x,
+            d_z,
+            k,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.dec_y = M2DecoderY(
+            d_x,
+            k,
+            d_z,
+            d_y,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
         self.k = k
         self.tau = tau
 
@@ -90,13 +142,66 @@ class M2VAE(nn.Module):
 class SS_CEVAE(nn.Module):
     """Semi-supervised variant of CEVAE."""
 
-    def __init__(self, d_x: int, d_y: int, k: int = 2, d_z: int = 16, tau: float = 0.5):
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k: int = 2,
+        d_z: int = 16,
+        tau: float = 0.5,
+        *,
+        hidden_dims=(128, 128),
+        activation=nn.ReLU,
+        dropout=None,
+        norm_layer=None,
+    ):
         super().__init__()
-        self.enc_z = CEncoderZ(d_x, k, d_y, d_z)
-        self.cls_t = CClassifierT(d_x, d_y, k)
-        self.dec_x = CDecoderX(d_z, d_x)
-        self.dec_t = CDecoderT(d_z, d_x, k)
-        self.dec_y = CDecoderY(d_z, d_x, k, d_y)
+        self.enc_z = CEncoderZ(
+            d_x,
+            k,
+            d_y,
+            d_z,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.cls_t = CClassifierT(
+            d_x,
+            d_y,
+            k,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.dec_x = CDecoderX(
+            d_z,
+            d_x,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.dec_t = CDecoderT(
+            d_z,
+            d_x,
+            k,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.dec_y = CDecoderY(
+            d_z,
+            d_x,
+            k,
+            d_y,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
         self.k = k
         self.tau = tau
 


### PR DESCRIPTION
## Summary
- support customisation of hidden dimensions, activation, dropout and normalisation when creating models
- propagate the new kwargs through all MLP‑based models
- test registry with custom MLP arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868cff0ddac83249a8d6ed4dd871c36