### PR TITLE
Add metrics module and refactor losses

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -19,7 +19,7 @@ def test_get_model_with_mlp_args():
     )
     layers = list(model.G_Y)
     assert isinstance(layers[1], nn.ReLU)
-    assert any(isinstance(l, nn.Dropout) for l in layers)
+    assert any(isinstance(layer, nn.Dropout) for layer in layers)
     assert layers[0].out_features == 16
 
 

--- a/xtylearner/models/cycle_dual.py
+++ b/xtylearner/models/cycle_dual.py
@@ -7,11 +7,12 @@
 
 import torch
 import torch.nn as nn
-from torch.nn.functional import one_hot, cross_entropy
+from torch.nn.functional import one_hot
 
 from .layers import make_mlp
 
 from .registry import register_model
+from ..training.metrics import cross_entropy_loss, mse_loss
 
 
 # ---------- dual-network module -----------------------------------------
@@ -79,13 +80,13 @@ class CycleDual(nn.Module):
         Y_cyc = self.G_Y(torch.cat([X_hat.detach(), T_1h], -1))
 
         # === STEP 3 : losses ==========================================
-        mse = nn.functional.mse_loss
+        mse = mse_loss
 
         # supervised parts (labelled rows only)
         L_sup_Y = mse(Y_hat[labelled], Y[labelled]) if labelled.any() else 0.0
         L_sup_X = mse(X_hat[labelled], X[labelled]) if labelled.any() else 0.0
         L_sup_T = (
-            cross_entropy(logits_T[labelled], T_obs[labelled])
+            cross_entropy_loss(logits_T[labelled], T_obs[labelled])
             if labelled.any()
             else 0.0
         )

--- a/xtylearner/models/flow_ssc.py
+++ b/xtylearner/models/flow_ssc.py
@@ -20,6 +20,7 @@ from nflows.transforms import (
 from nflows.nn.nets import ResidualNet
 
 from .registry import register_model
+from ..training.metrics import cross_entropy_loss
 
 
 def make_conditional_flow(
@@ -75,7 +76,7 @@ class MixtureOfFlows(nn.Module):
             xy_lab = torch.cat([X[t_lab_mask], Y[t_lab_mask]], dim=-1)
 
             ll_flow = self.flow.log_prob(xy_lab, context=ctx_lab)
-            ce_clf = nn.functional.cross_entropy(self.clf(X[t_lab_mask]), t_lab)
+            ce_clf = cross_entropy_loss(self.clf(X[t_lab_mask]), t_lab)
             loss_lab = -(ll_flow.mean() - ce_clf)  # maximise ll_flow
 
         # ---- un-labelled part -----------------------------------------

--- a/xtylearner/models/multitask_selftrain.py
+++ b/xtylearner/models/multitask_selftrain.py
@@ -17,8 +17,8 @@ import torch
 import torch.nn as nn
 
 from .layers import make_mlp
-
 from .registry import register_model
+from ..training.metrics import cross_entropy_loss, mse_loss
 
 
 # ------------------------------------------------------------
@@ -86,10 +86,9 @@ class MultiTask(nn.Module):
         """Simple supervised loss used for unit tests."""
         T_1h = torch.nn.functional.one_hot(T_obs, self.k).float()
         Y_hat, logits_T, X_hat = self.forward(X, Y, T_1h)
-        mse = nn.functional.mse_loss
-        L_y = mse(Y_hat, Y)
-        L_x = mse(X_hat, X)
-        L_t = nn.functional.cross_entropy(logits_T, T_obs)
+        L_y = mse_loss(Y_hat, Y)
+        L_x = mse_loss(X_hat, X)
+        L_t = cross_entropy_loss(logits_T, T_obs)
         return L_y + L_x + L_t
 
 

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -3,6 +3,13 @@
 from .base_trainer import BaseTrainer
 from .generative import M2VAE, SS_CEVAE, M2VAETrainer, CEVAETrainer
 from .supervised import SupervisedTrainer
+from .metrics import (
+    mse_loss,
+    mae_loss,
+    rmse_loss,
+    cross_entropy_loss,
+    accuracy,
+)
 
 __all__ = [
     "BaseTrainer",
@@ -11,4 +18,9 @@ __all__ = [
     "M2VAETrainer",
     "CEVAETrainer",
     "SupervisedTrainer",
+    "mse_loss",
+    "mae_loss",
+    "rmse_loss",
+    "cross_entropy_loss",
+    "accuracy",
 ]

--- a/xtylearner/training/metrics.py
+++ b/xtylearner/training/metrics.py
@@ -1,1 +1,46 @@
-# central place for PEHE, ATE, MSE_X recon, classifier acc.
+"""Common metrics and loss functions used across trainers and models."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def mse_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Mean squared error."""
+
+    return F.mse_loss(pred, target)
+
+
+def mae_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Mean absolute error."""
+
+    return torch.mean(torch.abs(pred - target))
+
+
+def rmse_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Root mean squared error."""
+
+    return torch.sqrt(mse_loss(pred, target))
+
+
+def cross_entropy_loss(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Cross entropy for classification."""
+
+    return F.cross_entropy(logits, target)
+
+
+def accuracy(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Classification accuracy for ``logits`` compared with ``target``."""
+
+    pred = logits.argmax(dim=-1)
+    return (pred == target).float().mean()
+
+
+__all__ = [
+    "mse_loss",
+    "mae_loss",
+    "rmse_loss",
+    "cross_entropy_loss",
+    "accuracy",
+]


### PR DESCRIPTION
## Summary
- centralize metrics and losses in `training.metrics`
- expose the metrics in the training package
- refactor models to use new metric helpers
- tweak tests for lint compliance

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868d3a9daec8324a8411399be99f796