### PR TITLE
Add JSBF diffusion model

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2,8 +2,8 @@ import torch
 from torch.utils.data import DataLoader
 from xtylearner.data import load_toy_dataset, load_mixed_synthetic_dataset
 from xtylearner.models import CycleDual, MixtureOfFlows, MultiTask
-from xtylearner.training import SupervisedTrainer, GenerativeTrainer
-from xtylearner.models import M2VAE, SS_CEVAE
+from xtylearner.training import SupervisedTrainer, GenerativeTrainer, DiffusionTrainer
+from xtylearner.models import M2VAE, SS_CEVAE, JSBF
 
 
 def test_supervised_trainer_runs():
@@ -78,6 +78,17 @@ def test_cevae_trainer_mixed_dataset():
     model = SS_CEVAE(d_x=2, d_y=1, k=2)
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = GenerativeTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_jsbf_trainer_runs():
+    dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=7, label_ratio=0.5)
+    loader = DataLoader(dataset, batch_size=5)
+    model = JSBF(d_x=2, d_y=1)
+    opt = torch.optim.Adam(model.parameters(), lr=0.001)
+    trainer = DiffusionTrainer(model, opt, loader)
     trainer.fit(1)
     loss = trainer.evaluate(loader)
     assert isinstance(loss, float)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -4,6 +4,7 @@ from .cycle_dual import CycleDual
 from .flow_ssc import MixtureOfFlows
 from .multitask_selftrain import MultiTask
 from .generative import M2VAE, SS_CEVAE
+from .jsbf_model import JSBF
 from .registry import get_model
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "MultiTask",
     "M2VAE",
     "SS_CEVAE",
+    "JSBF",
     "get_model",
 ]

--- a/xtylearner/models/generative.py
+++ b/xtylearner/models/generative.py
@@ -2,5 +2,6 @@
 
 from .m2vae_model import M2VAE
 from .ss_cevae_model import SS_CEVAE
+from .jsbf_model import JSBF
 
-__all__ = ["M2VAE", "SS_CEVAE"]
+__all__ = ["M2VAE", "SS_CEVAE", "JSBF"]

--- a/xtylearner/models/jsbf_model.py
+++ b/xtylearner/models/jsbf_model.py
@@ -1,0 +1,144 @@
+"""Joint Score-Based Factorisation model."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .registry import register_model
+
+
+class ScoreNet(nn.Module):
+    """Simple score network predicting continuous and discrete scores."""
+
+    def __init__(self, d_x: int, d_y: int, hidden: int) -> None:
+        super().__init__()
+        self.t_embed = nn.Embedding(2, hidden)
+        self.time_mlp = nn.Sequential(
+            nn.Linear(1, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+        )
+        self.trunk = nn.Sequential(
+            nn.Linear(d_x + d_y + hidden * 2, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+        )
+        self.score_head = nn.Linear(hidden, d_x + d_y)
+        self.class_head = nn.Linear(hidden, 2)
+
+    def forward(
+        self, xy: torch.Tensor, t_corrupt: torch.Tensor, tau: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        t_emb = self.t_embed(t_corrupt)
+        time_emb = self.time_mlp(tau)
+        h = torch.cat([xy, t_emb, time_emb], dim=-1)
+        h = self.trunk(h)
+        score = self.score_head(h)
+        logits = self.class_head(h)
+        return score, logits
+
+
+@register_model("jsbf")
+class JSBF(nn.Module):
+    """Joint Score-Based Factorisation.
+
+    Parameters
+    ----------
+    d_x:
+        Dimensionality of covariates ``X``.
+    d_y:
+        Dimensionality of outcomes ``Y``.
+    hidden:
+        Hidden dimension for the score network.
+    timesteps:
+        Number of diffusion steps.
+    sigma_min, sigma_max:
+        Minimum and maximum noise levels.
+    """
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        *,
+        hidden: int = 256,
+        timesteps: int = 1000,
+        sigma_min: float = 0.002,
+        sigma_max: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.d_x = d_x
+        self.d_y = d_y
+        self.hidden = hidden
+        self.timesteps = timesteps
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
+        self.net = ScoreNet(d_x, d_y, hidden)
+
+    # ----- diffusion utilities -----
+    def _sigma(self, t: torch.Tensor) -> torch.Tensor:
+        return self.sigma_min * (self.sigma_max / self.sigma_min) ** t
+
+    def _q_sample_continuous(self, x0: torch.Tensor, t_idx: torch.Tensor):
+        eps = torch.randn_like(x0)
+        sig_t = self._sigma(t_idx.float() / self.timesteps).view(-1, 1)
+        xt = x0 + sig_t * eps
+        return xt, eps, sig_t
+
+    def _q_sample_discrete(self, t0: torch.Tensor, t_idx: torch.Tensor):
+        gamma = (t_idx.float() / self.timesteps).view(-1)
+        rand = torch.randint(0, 2, t0.shape, device=t0.device)
+        keep = torch.bernoulli(1 - gamma).bool()
+        return torch.where(keep, t0, rand)
+
+    # ----- training objective -----
+    def loss(self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor) -> torch.Tensor:
+        b = x.size(0)
+        t_idx = torch.randint(1, self.timesteps + 1, (b,), device=x.device)
+        xy0 = torch.cat([x, y], dim=-1)
+        xy_t, eps, sig_t = self._q_sample_continuous(xy0, t_idx)
+
+        t_mask = t_obs != -1
+        t_cln = t_obs.clamp_min(0)
+        t_corrupt = self._q_sample_discrete(t_cln, t_idx)
+        tau = (t_idx.float() / self.timesteps).unsqueeze(-1)
+
+        score_pred, logits_pred = self.net(xy_t, t_corrupt, tau)
+
+        score_loss = ((score_pred + eps / sig_t) ** 2).mean()
+        if t_mask.any():
+            cls_loss = F.cross_entropy(logits_pred[t_mask], t_cln[t_mask])
+        else:
+            cls_loss = torch.tensor(0.0, device=x.device)
+        return score_loss + cls_loss
+
+    # ----- simple sampler -----
+    @torch.no_grad()
+    def sample(self, n: int, extra_noise: float = 1.0):
+        xy = torch.randn(n, self.d_x + self.d_y, device=self.net.score_head.weight.device)
+        xy = xy * self.sigma_max * extra_noise
+        t = torch.randint(0, 2, (n,), device=xy.device)
+
+        for t_idx in reversed(range(1, self.timesteps + 1)):
+            tau = torch.full((n, 1), t_idx / self.timesteps, device=xy.device)
+            sig_t = self._sigma(tau)
+            score, logits = self.net(xy, t, tau)
+            xy = xy + (sig_t ** 2) * score
+            if t_idx > 1:
+                prev = (t_idx - 1) / self.timesteps
+                noise_scale = (sig_t ** 2 - self._sigma(torch.tensor(prev, device=xy.device)) ** 2).sqrt()
+                xy = xy + noise_scale * torch.randn_like(xy)
+            probs = F.softmax(logits, -1)
+            t = torch.multinomial(probs, 1).squeeze(-1)
+
+        x = xy[:, : self.d_x]
+        y = xy[:, self.d_x :]
+        return x.cpu(), y.cpu(), t.cpu()
+
+
+__all__ = ["JSBF"]

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -3,6 +3,7 @@
 from .base_trainer import BaseTrainer
 from .generative import GenerativeTrainer
 from .supervised import SupervisedTrainer
+from .diffusion import DiffusionTrainer
 from .metrics import (
     mse_loss,
     mae_loss,
@@ -15,6 +16,7 @@ __all__ = [
     "BaseTrainer",
     "GenerativeTrainer",
     "SupervisedTrainer",
+    "DiffusionTrainer",
     "mse_loss",
     "mae_loss",
     "rmse_loss",

--- a/xtylearner/training/diffusion.py
+++ b/xtylearner/training/diffusion.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+
+from .base_trainer import BaseTrainer
+
+
+class DiffusionTrainer(BaseTrainer):
+    """Trainer for score-based diffusion models like JSBF."""
+
+    def step(self, batch: Iterable[torch.Tensor]) -> torch.Tensor:
+        x, y, t = [b.to(self.device) for b in batch]
+        return self.model.loss(x, y, t)
+
+    def fit(self, num_epochs: int) -> None:
+        for _ in range(num_epochs):
+            self.model.train()
+            for batch in self.train_loader:
+                loss = self.step(batch)
+                self.optimizer.zero_grad()
+                loss.backward()
+                self.optimizer.step()
+
+    def evaluate(self, data_loader: Iterable) -> float:
+        self.model.eval()
+        total, n = 0.0, 0
+        with torch.no_grad():
+            for batch in data_loader:
+                loss = self.step(batch)
+                total += float(loss.item()) * len(batch[0])
+                n += len(batch[0])
+        return total / max(n, 1)
+
+    def predict(self, n: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        self.model.eval()
+        with torch.no_grad():
+            return self.model.sample(n)
+
+
+__all__ = ["DiffusionTrainer"]


### PR DESCRIPTION
## Summary
- implement Joint Score-Based Factorisation model for diffusion-based training
- add `DiffusionTrainer` for score-based models
- expose JSBF in model and trainer registries
- extend unit tests with JSBF training run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68699da68eec8324ac34ccf3b007a7d3