### PR TITLE
Implement Energy-guided Discrete Diffusion Imputer

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,11 @@
 import pytest
 import torch.nn as nn
-from xtylearner.models import get_model, CycleDual, DiffusionCEVAE
+from xtylearner.models import (
+    get_model,
+    CycleDual,
+    DiffusionCEVAE,
+    EnergyDiffusionImputer,
+)
 
 
 def test_get_model_valid():
@@ -9,6 +14,9 @@ def test_get_model_valid():
 
     model2 = get_model("diffusion_cevae", d_x=2, d_y=1, k=2)
     assert isinstance(model2, DiffusionCEVAE)
+
+    model3 = get_model("eg_ddi", d_x=2, d_y=1)
+    assert isinstance(model3, EnergyDiffusionImputer)
 
 
 def test_get_model_with_mlp_args():

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -5,6 +5,7 @@ from xtylearner.models import CycleDual, MixtureOfFlows, MultiTask
 from xtylearner.training import SupervisedTrainer, GenerativeTrainer, DiffusionTrainer
 from xtylearner.models import M2VAE, SS_CEVAE, JSBF, DiffusionCEVAE
 from xtylearner.models import BridgeDiff, LTFlowDiff
+from xtylearner.models import EnergyDiffusionImputer
 
 
 def test_supervised_trainer_runs():
@@ -125,6 +126,19 @@ def test_lt_flow_diff_trainer_runs():
     model = LTFlowDiff(d_x=2, d_y=1)
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = GenerativeTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_eg_ddi_trainer_runs():
+    dataset = load_mixed_synthetic_dataset(
+        n_samples=20, d_x=2, seed=11, label_ratio=0.5
+    )
+    loader = DataLoader(dataset, batch_size=5)
+    model = EnergyDiffusionImputer(d_x=2, d_y=1)
+    opt = torch.optim.Adam(model.parameters(), lr=0.001)
+    trainer = DiffusionTrainer(model, opt, loader)
     trainer.fit(1)
     loss = trainer.evaluate(loader)
     assert isinstance(loss, float)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -4,6 +4,7 @@ from .cycle_dual import CycleDual
 from .flow_ssc import MixtureOfFlows
 from .multitask_selftrain import MultiTask
 from .generative import M2VAE, SS_CEVAE, DiffusionCEVAE
+from .energy_diffusion_imputer import EnergyDiffusionImputer
 from .jsbf_model import JSBF
 from .bridge_diff import BridgeDiff
 from .lt_flow_diff import LTFlowDiff
@@ -19,5 +20,6 @@ __all__ = [
     "JSBF",
     "BridgeDiff",
     "LTFlowDiff",
+    "EnergyDiffusionImputer",
     "get_model",
 ]

--- a/xtylearner/models/energy_diffusion_imputer.py
+++ b/xtylearner/models/energy_diffusion_imputer.py
@@ -1,0 +1,137 @@
+"""Energy-guided Discrete Diffusion Imputer (EG-DDI)."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .registry import register_model
+
+
+class ScoreNet(nn.Module):
+    """Score network predicting logits for the reverse diffusion."""
+
+    def __init__(self, d_x: int, d_y: int, hidden: int = 128) -> None:
+        super().__init__()
+        self.x_proj = nn.Linear(d_x, hidden)
+        self.y_proj = nn.Linear(d_y, hidden)
+        self.time_fc = nn.Sequential(
+            nn.Linear(1, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+        )
+        self.trunk = nn.Sequential(
+            nn.Linear(hidden * 3, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, 2),
+        )
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor, tau: torch.Tensor) -> torch.Tensor:
+        h = torch.cat([self.x_proj(x), self.y_proj(y), self.time_fc(tau)], dim=-1)
+        return self.trunk(h)
+
+
+class EnergyNet(nn.Module):
+    """Simple energy model over ``(x,y,t)``."""
+
+    def __init__(self, d_x: int, d_y: int, hidden: int = 128) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(d_x + d_y, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, 2),
+        )
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return self.net(torch.cat([x, y], dim=-1))
+
+
+@register_model("eg_ddi")
+class EnergyDiffusionImputer(nn.Module):
+    """Energy-guided Discrete Diffusion Imputer."""
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        *,
+        timesteps: int = 1000,
+        hidden: int = 128,
+        lr: float = 2e-4,
+    ) -> None:
+        super().__init__()
+        self.d_x = d_x
+        self.d_y = d_y
+        self.timesteps = timesteps
+        self.score_net = ScoreNet(d_x, d_y, hidden)
+        self.energy_net = EnergyNet(d_x, d_y, hidden)
+        self.optimizer = torch.optim.Adam(self.parameters(), lr=lr)
+
+    # ----- utilities -----
+    def _gamma(self, k: torch.Tensor) -> torch.Tensor:
+        return k.float() / self.timesteps
+
+    # ----- training objective -----
+    def loss(self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor) -> torch.Tensor:
+        b = x.size(0)
+        device = x.device
+        k = torch.randint(1, self.timesteps + 1, (b,), device=device)
+        tau = k.float().unsqueeze(-1) / self.timesteps
+        gam = self._gamma(k).unsqueeze(-1)
+
+        t_clean = t_obs.clone()
+        missing = t_obs == -1
+        if missing.any():
+            t_clean[missing] = torch.randint(0, 2, (missing.sum(),), device=device)
+        flip = torch.bernoulli(gam).bool().squeeze(-1)
+        t_noisy = torch.where(flip, 1 - t_clean, t_clean)
+
+        logits = self.score_net(x, y, tau)
+
+        obs_mask = t_obs != -1
+        loss_obs = torch.tensor(0.0, device=device)
+        if obs_mask.any():
+            loss_obs = F.cross_entropy(logits[obs_mask], t_obs[obs_mask])
+
+        loss_unobs = torch.tensor(0.0, device=device)
+        if missing.any():
+            E = self.energy_net(x[missing], y[missing])
+            w = F.softmax(-E, dim=-1)
+            ce0 = F.cross_entropy(logits[missing], torch.zeros_like(t_obs[missing]), reduction="none")
+            ce1 = F.cross_entropy(logits[missing], torch.ones_like(t_obs[missing]), reduction="none")
+            loss_unobs = (w[:, 0] * ce0 + w[:, 1] * ce1).mean()
+
+        E_all = self.energy_net(x, y)
+        t_pos = torch.where(obs_mask, t_obs, logits.argmax(dim=-1))
+        E_pos = E_all.gather(1, t_pos.unsqueeze(-1)).squeeze(-1)
+        cd_loss = (E_pos + torch.logsumexp(-E_all, dim=-1)).mean()
+
+        return loss_obs + loss_unobs + cd_loss
+
+    # ----- optimizer helper -----
+    def step(self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor) -> torch.Tensor:
+        loss = self.loss(x, y, t_obs)
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        return loss
+
+    # ----- simple sampler -----
+    @torch.no_grad()
+    def sample_T(self, x: torch.Tensor, y: torch.Tensor, steps: int = 30):
+        b = x.size(0)
+        t = torch.randint(0, 2, (b,), device=x.device)
+        for k in reversed(range(1, steps + 1)):
+            tau = torch.full((b, 1), k / steps, device=x.device)
+            logits = self.score_net(x, y, tau)
+            energy = self.energy_net(x, y)
+            guided = logits - energy
+            probs = F.softmax(guided, dim=-1)
+            t = torch.multinomial(probs, 1).squeeze(-1)
+        return t
+
+
+__all__ = ["EnergyDiffusionImputer"]

--- a/xtylearner/models/generative.py
+++ b/xtylearner/models/generative.py
@@ -6,6 +6,7 @@ from .jsbf_model import JSBF
 from .diffusion_cevae import DiffusionCEVAE
 from .bridge_diff import BridgeDiff
 from .lt_flow_diff import LTFlowDiff
+from .energy_diffusion_imputer import EnergyDiffusionImputer
 
 __all__ = [
     "M2VAE",
@@ -14,4 +15,5 @@ __all__ = [
     "JSBF",
     "BridgeDiff",
     "LTFlowDiff",
+    "EnergyDiffusionImputer",
 ]


### PR DESCRIPTION
## Summary
- add EnergyDiffusionImputer model implementing EG-DDI
- export the model via `__init__` and generative wrappers
- register EG-DDI in model registry tests
- train EG-DDI in trainer tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d0b93e608324a2ed24bf58fafe7c