### PR TITLE
Enable multiclass treatments

### DIFF
--- a/xtylearner/models/bridge_diff.py
+++ b/xtylearner/models/bridge_diff.py
@@ -11,10 +11,10 @@ class ScoreBridge(nn.Module):
     """Score network predicting ``\nabla_y log q(y_\tau | x,t)``."""
 
     def __init__(
-        self, d_x: int, d_y: int, hidden: int = 256, embed_dim: int = 64
+        self, d_x: int, d_y: int, k: int, hidden: int = 256, embed_dim: int = 64
     ) -> None:
         super().__init__()
-        self.t_embed = nn.Embedding(2, embed_dim)
+        self.t_embed = nn.Embedding(k, embed_dim)
         self.time_mlp = nn.Sequential(
             nn.Linear(1, embed_dim),
             nn.SiLU(),
@@ -42,12 +42,12 @@ class ScoreBridge(nn.Module):
 class Classifier(nn.Module):
     """Classifier head estimating ``p(t|x,y)``."""
 
-    def __init__(self, d_x: int, d_y: int, hidden: int = 128) -> None:
+    def __init__(self, d_x: int, d_y: int, k: int, hidden: int = 128) -> None:
         super().__init__()
         self.net = nn.Sequential(
             nn.Linear(d_x + d_y, hidden),
             nn.ReLU(),
-            nn.Linear(hidden, 2),
+            nn.Linear(hidden, k),
         )
 
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -67,14 +67,16 @@ class BridgeDiff(nn.Module):
         timesteps: int = 1000,
         sigma_min: float = 0.002,
         sigma_max: float = 1.0,
+        k: int = 2,
     ) -> None:
         super().__init__()
         self.d_y = d_y
+        self.k = k
         self.timesteps = timesteps
         self.sigma_min = sigma_min
         self.sigma_max = sigma_max
-        self.score_net = ScoreBridge(d_x, d_y, hidden)
-        self.classifier = Classifier(d_x, d_y)
+        self.score_net = ScoreBridge(d_x, d_y, k, hidden)
+        self.classifier = Classifier(d_x, d_y, k)
 
     # ----- utilities -----
     def _sigma(self, t: torch.Tensor) -> torch.Tensor:
@@ -109,25 +111,18 @@ class BridgeDiff(nn.Module):
         unobs_mask = obs_mask.logical_not()
         loss_unobs = torch.tensor(0.0, device=device)
         if unobs_mask.any():
-            t0 = torch.zeros_like(t_obs[unobs_mask])
-            t1 = torch.ones_like(t_obs[unobs_mask])
-            s0 = self.score_net(
-                y_noisy[unobs_mask],
-                x[unobs_mask],
-                t0,
-                tau[unobs_mask].unsqueeze(-1),
-            )
-            s1 = self.score_net(
-                y_noisy[unobs_mask],
-                x[unobs_mask],
-                t1,
-                tau[unobs_mask].unsqueeze(-1),
-            )
-            mse0 = ((s0 + eps[unobs_mask] / sig[unobs_mask]) ** 2).mean(dim=-1)
-            mse1 = ((s1 + eps[unobs_mask] / sig[unobs_mask]) ** 2).mean(dim=-1)
-            w0 = p_post[unobs_mask, 0]
-            w1 = p_post[unobs_mask, 1]
-            loss_unobs = (w0 * mse0 + w1 * mse1).mean()
+            mse_all = []
+            for t_val in range(self.k):
+                s_t = self.score_net(
+                    y_noisy[unobs_mask],
+                    x[unobs_mask],
+                    torch.full_like(t_obs[unobs_mask], t_val),
+                    tau[unobs_mask].unsqueeze(-1),
+                )
+                mse = ((s_t + eps[unobs_mask] / sig[unobs_mask]) ** 2).mean(dim=-1)
+                mse_all.append(mse)
+            mse_all = torch.stack(mse_all, dim=1)
+            loss_unobs = (p_post[unobs_mask] * mse_all).sum(dim=1).mean()
 
         ce_loss = torch.tensor(0.0, device=device)
         if obs_mask.any():
@@ -139,37 +134,29 @@ class BridgeDiff(nn.Module):
     @torch.no_grad()
     def paired_sample(
         self, x: torch.Tensor, n_steps: int = 50
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Generate one coupled draw ``(y0, y1)`` for each row in ``x``."""
+    ) -> tuple[torch.Tensor, ...]:
+        """Generate one draw ``y_t`` for each treatment ``t``."""
         b = x.size(0)
         device = x.device
-        y0 = torch.randn(b, self.d_y, device=device) * self.sigma_max
-        y1 = y0.clone()
+        y = torch.randn(b, self.k, self.d_y, device=device) * self.sigma_max
 
         for k in reversed(range(1, n_steps + 1)):
             tau = torch.full((b, 1), k / n_steps, device=device)
             sig = self._sigma(tau)
-            score0 = self.score_net(
-                y0,
-                x,
-                torch.zeros(b, dtype=torch.long, device=device),
-                tau,
-            )
-            score1 = self.score_net(
-                y1,
-                x,
-                torch.ones(b, dtype=torch.long, device=device),
-                tau,
-            )
-            y0 = y0 + (sig**2) * score0
-            y1 = y1 + (sig**2) * score1
+            for t_val in range(self.k):
+                score = self.score_net(
+                    y[:, t_val],
+                    x,
+                    torch.full((b,), t_val, dtype=torch.long, device=device),
+                    tau,
+                )
+                y[:, t_val] = y[:, t_val] + (sig**2) * score
             if k > 1:
                 prev = tau - 1 / n_steps
                 noise_scale = (sig**2 - self._sigma(prev).pow(2)).sqrt()
-                noise = torch.randn_like(y0)
-                y0 = y0 + noise_scale * noise
-                y1 = y1 + noise_scale * noise
-        return y0, y1
+                noise = torch.randn_like(y[:, 0])
+                y = y + noise_scale * noise.unsqueeze(1)
+        return tuple(y[:, t] for t in range(self.k))
 
     # ----- posterior utility -----
     @torch.no_grad()

--- a/xtylearner/models/gflownet_treatment.py
+++ b/xtylearner/models/gflownet_treatment.py
@@ -15,14 +15,18 @@ from .registry import register_model
 class OutcomeModel(nn.Module):
     """Simple outcome likelihood model ``p_phi(y|x,t)``."""
 
-    def __init__(self, d_x: int, d_y: int, hidden: int = 128) -> None:
+    def __init__(self, d_x: int, d_y: int, k: int, hidden: int = 128) -> None:
         super().__init__()
+        self.k = k
         self.net = nn.Sequential(
-            nn.Linear(d_x + 1, hidden), nn.ReLU(), nn.Linear(hidden, d_y * 2)
+            nn.Linear(d_x + k, hidden), nn.ReLU(), nn.Linear(hidden, d_y * 2)
         )
 
-    def forward(self, x: torch.Tensor, t: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        h = self.net(torch.cat([x, t.unsqueeze(-1)], dim=-1))
+    def forward(
+        self, x: torch.Tensor, t: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        t_onehot = F.one_hot(t.to(torch.long), num_classes=self.k).float()
+        h = self.net(torch.cat([x, t_onehot], dim=-1))
         mu, log_sigma = h.chunk(2, dim=-1)
         sigma = 0.1 + 0.9 * torch.sigmoid(log_sigma)
         return mu, sigma
@@ -31,10 +35,10 @@ class OutcomeModel(nn.Module):
 class PolicyNet(nn.Module):
     """Policy network predicting logits ``log pi(t|x,y)``."""
 
-    def __init__(self, d_x: int, d_y: int, hidden: int = 128) -> None:
+    def __init__(self, d_x: int, d_y: int, k: int, hidden: int = 128) -> None:
         super().__init__()
         self.net = nn.Sequential(
-            nn.Linear(d_x + d_y, hidden), nn.ReLU(), nn.Linear(hidden, 2)
+            nn.Linear(d_x + d_y, hidden), nn.ReLU(), nn.Linear(hidden, k)
         )
 
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -58,12 +62,13 @@ class FlowNet(nn.Module):
 class GFlowNetTreatment(nn.Module):
     """Minimal GFlowNet that samples treatments in proportion to outcome likelihood."""
 
-    def __init__(self, d_x: int, d_y: int) -> None:
+    def __init__(self, d_x: int, d_y: int, k: int = 2) -> None:
         super().__init__()
         self.d_x = d_x
         self.d_y = d_y
-        self.outcome = OutcomeModel(d_x, d_y)
-        self.policy = PolicyNet(d_x, d_y)
+        self.k = k
+        self.outcome = OutcomeModel(d_x, d_y, k)
+        self.policy = PolicyNet(d_x, d_y, k)
         self.flow = FlowNet(d_x, d_y)
 
     # --------------------------------------------------------------
@@ -75,17 +80,15 @@ class GFlowNetTreatment(nn.Module):
         b = x.size(0)
         device = x.device
 
-        # outcome likelihoods for both treatment choices
-        t0 = torch.zeros(b, dtype=torch.float32, device=device)
-        t1 = torch.ones(b, dtype=torch.float32, device=device)
-        mu0, s0 = self.outcome(x, t0)
-        mu1, s1 = self.outcome(x, t1)
-        ll0 = -0.5 * (
-            ((y - mu0) / s0) ** 2 + 2 * s0.log() + math.log(2 * math.pi)
-        ).sum(-1)
-        ll1 = -0.5 * (
-            ((y - mu1) / s1) ** 2 + 2 * s1.log() + math.log(2 * math.pi)
-        ).sum(-1)
+        ll_list = []
+        for t_val in range(self.k):
+            t_vec = torch.full((b,), t_val, dtype=torch.long, device=device)
+            mu, s = self.outcome(x, t_vec)
+            ll = -0.5 * (((y - mu) / s) ** 2 + 2 * s.log() + math.log(2 * math.pi)).sum(
+                -1
+            )
+            ll_list.append(ll)
+        ll_all = torch.stack(ll_list, dim=1)
 
         # sample action from policy or use observed treatment
         log_pi = self.policy(x, y)
@@ -97,7 +100,7 @@ class GFlowNetTreatment(nn.Module):
         log_pi_a = log_pi.gather(1, act.unsqueeze(-1)).squeeze(-1)
 
         # reward = outcome likelihood
-        R = torch.where(act == 0, ll0.exp(), ll1.exp())
+        R = ll_all.gather(1, act.unsqueeze(-1)).squeeze(-1).exp()
         R = torch.clamp(R, min=1e-6)
 
         # trajectory balance loss (one-step case)
@@ -105,14 +108,12 @@ class GFlowNetTreatment(nn.Module):
         tb_loss = ((F_root + log_pi_a - R.log()) ** 2).mean()
 
         # supervised outcome loss for labelled rows
-        ll_obs = torch.where(
-            t_obs == 0,
-            ll0,
-            torch.where(t_obs == 1, ll1, torch.zeros_like(ll0)),
-        )
+        ll_obs = ll_all.gather(1, t_obs.clamp_min(0).unsqueeze(-1)).squeeze(-1)
         obs_mask = t_obs != -1
         outcome_loss = (
-            -(ll_obs[obs_mask]).mean() if obs_mask.any() else torch.tensor(0.0, device=device)
+            -(ll_obs[obs_mask]).mean()
+            if obs_mask.any()
+            else torch.tensor(0.0, device=device)
         )
 
         return tb_loss + outcome_loss


### PR DESCRIPTION
## Summary
- add `k` parameter to BridgeDiff, EnergyDiffusionImputer, GFlowNetTreatment, JointEBM, JSBF, and LTFlowDiff
- update diffusion, score, and classifier components to handle k-way treatments
- adjust sampling and loss logic for arbitrary treatment counts

## Testing
- `pre-commit run --files xtylearner/models/energy_diffusion_imputer.py xtylearner/models/jsbf_model.py xtylearner/models/bridge_diff.py xtylearner/models/joint_ebm.py xtylearner/models/gflownet_treatment.py xtylearner/models/lt_flow_diff.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a3ff793d08324878c7b1f283c36eb