### PR TITLE
Add training metrics for treatment classes

### DIFF
--- a/xtylearner/training/diffusion.py
+++ b/xtylearner/training/diffusion.py
@@ -21,12 +21,14 @@ class DiffusionTrainer(BaseTrainer):
             if self.logger:
                 self.logger.start_epoch(epoch + 1, num_batches)
             for batch_idx, batch in enumerate(self.train_loader):
+                X, Y, T_obs = self._extract_batch(batch)
                 loss = self.step(batch)
                 self.optimizer.zero_grad()
                 loss.backward()
                 self.optimizer.step()
                 if self.logger:
-                    metrics = self._metrics_from_loss(loss)
+                    metrics = dict(self._metrics_from_loss(loss))
+                    metrics.update(self._treatment_metrics(X, Y, T_obs))
                     self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
             if self.logger:
                 self.logger.end_epoch(epoch + 1)

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -30,12 +30,14 @@ class GenerativeTrainer(BaseTrainer):
             if self.logger:
                 self.logger.start_epoch(epoch + 1, num_batches)
             for batch_idx, batch in enumerate(self.train_loader):
+                X, Y, T_obs = self._extract_batch(batch)
                 loss = self.step(batch)
                 self.optimizer.zero_grad()
                 loss.backward()
                 self.optimizer.step()
                 if self.logger:
-                    metrics = self._metrics_from_loss(loss)
+                    metrics = dict(self._metrics_from_loss(loss))
+                    metrics.update(self._treatment_metrics(X, Y, T_obs))
                     self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
             if self.logger:
                 self.logger.end_epoch(epoch + 1)

--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -31,12 +31,14 @@ class SupervisedTrainer(BaseTrainer):
             if self.logger:
                 self.logger.start_epoch(epoch + 1, num_batches)
             for batch_idx, batch in enumerate(self.train_loader):
+                X, Y, T_obs = self._extract_batch(batch)
                 loss = self.step(batch)
                 self.optimizer.zero_grad()
                 loss.backward()
                 self.optimizer.step()
                 if self.logger:
-                    metrics = self._metrics_from_loss(loss)
+                    metrics = dict(self._metrics_from_loss(loss))
+                    metrics.update(self._treatment_metrics(X, Y, T_obs))
                     self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
             if self.logger:
                 self.logger.end_epoch(epoch + 1)


### PR DESCRIPTION
## Summary
- add helper methods to extract batches and compute treatment metrics
- log NLL and accuracy for treatment predictions during training

## Testing
- `pre-commit run --files xtylearner/training/base_trainer.py xtylearner/training/supervised.py xtylearner/training/generative.py xtylearner/training/diffusion.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6a653ed883249052ec4c189c06ac