### PR TITLE
Fix CLI training entrypoint

### DIFF
--- a/xtylearner/scripts/train.py
+++ b/xtylearner/scripts/train.py
@@ -33,13 +33,19 @@ def main() -> None:
     cfg = load_config(cfg_path)
 
     dataset_cfg = cfg.get("dataset", {})
-    dataset_name = args.dataset or dataset_cfg.get("name", "toy")
-    dataset_params = dataset_cfg.get("params", {})
+    dataset_name = args.dataset if args.dataset else dataset_cfg.get("name", "toy")
+    if dataset_name == dataset_cfg.get("name"):
+        dataset_params = dataset_cfg.get("params", {})
+    else:
+        dataset_params = {}
     dataset = get_dataset(dataset_name, **dataset_params)
 
     model_cfg = cfg.get("model", {})
-    model_name = args.model or model_cfg.get("name")
-    model_params = model_cfg.get("params", {})
+    model_name = args.model if args.model else model_cfg.get("name")
+    if model_name == model_cfg.get("name"):
+        model_params = model_cfg.get("params", {})
+    else:
+        model_params = {}
     model = get_model(model_name, **model_params)
 
     train_cfg = cfg.get("training", {})

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -3,6 +3,9 @@
 from .base_trainer import BaseTrainer
 from .logger import TrainerLogger, ConsoleLogger
 from .trainer import Trainer
+from .supervised import SupervisedTrainer
+from .generative import GenerativeTrainer
+from .diffusion import DiffusionTrainer
 from .metrics import (
     mse_loss,
     mae_loss,
@@ -13,6 +16,9 @@ from .metrics import (
 
 __all__ = [
     "BaseTrainer",
+    "SupervisedTrainer",
+    "GenerativeTrainer",
+    "DiffusionTrainer",
     "Trainer",
     "TrainerLogger",
     "ConsoleLogger",


### PR DESCRIPTION
## Summary
- expose trainer subclasses in `xtylearner.training`
- make `xtylearner-train` gracefully handle overriding model/dataset

## Testing
- `ruff check --fix xtylearner/scripts/train.py xtylearner/training/__init__.py`
- `black xtylearner/scripts/train.py xtylearner/training/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b03e15cf883249c4eaba917dee6a7