### PR TITLE
Fix packaging to include submodules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
 [project.scripts]
 xtylearner-train = "xtylearner.scripts.train:main"
 
-[tool.setuptools]
-packages = ["xtylearner"]
+[tool.setuptools.packages.find]
+include = ["xtylearner*"]
 
 [tool.pytest.ini_options]
 addopts = "-vv"

--- a/tests/test_package_install.py
+++ b/tests/test_package_install.py
@@ -1,0 +1,22 @@
+import importlib.util
+import subprocess
+import sys
+
+
+def test_package_includes_models(tmp_path):
+    install_dir = tmp_path / "install"
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        ".",
+        "-t",
+        str(install_dir),
+    ])
+    sys.path.insert(0, str(install_dir))
+    try:
+        assert importlib.util.find_spec("xtylearner.models") is not None
+    finally:
+        sys.path.pop(0)


### PR DESCRIPTION
## Summary
- include all xtylearner subpackages in the wheel
- add regression test ensuring xtylearner.models can be imported after installation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b06aa4998832490ff022c5cc205d1