### PR TITLE
Fix missing default config in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ xtylearner-train = "xtylearner.scripts.train:main"
 [tool.setuptools.packages.find]
 include = ["xtylearner*"]
 
+[tool.setuptools.package-data]
+xtylearner = ["configs/*.yaml"]
+
 [tool.pytest.ini_options]
 addopts = "-vv"
 testpaths = ["tests"]

--- a/tests/test_package_install.py
+++ b/tests/test_package_install.py
@@ -5,18 +5,38 @@ import sys
 
 def test_package_includes_models(tmp_path):
     install_dir = tmp_path / "install"
-    subprocess.check_call([
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--no-deps",
-        ".",
-        "-t",
-        str(install_dir),
-    ])
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            ".",
+            "-t",
+            str(install_dir),
+        ]
+    )
     sys.path.insert(0, str(install_dir))
     try:
         assert importlib.util.find_spec("xtylearner.models") is not None
     finally:
         sys.path.pop(0)
+
+
+def test_package_includes_default_config(tmp_path):
+    install_dir = tmp_path / "install"
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            ".",
+            "-t",
+            str(install_dir),
+        ]
+    )
+    cfg_path = install_dir / "xtylearner" / "configs" / "default.yaml"
+    assert cfg_path.is_file()


### PR DESCRIPTION
## Summary
- bundle default YAML config so the train CLI works
- ensure install test checks for the default config

## Testing
- `pre-commit run --files pyproject.toml tests/test_package_install.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0bbb3648832491b1c684204cc999