### PR TITLE
Standardize dimension args in models

### DIFF
--- a/tests/test_em_model.py
+++ b/tests/test_em_model.py
@@ -18,7 +18,7 @@ def _generate_data(n=20, k=3, seed=0):
 
 def test_em_learn_default_runs():
     X, Y, T = _generate_data(n=15, k=2, seed=1)
-    clf, regs, s2, T_hat = em_learn(X, Y, T, n_treatments=2, max_iter=2)
+    clf, regs, s2, T_hat = em_learn(X, Y, T, k=2, max_iter=2)
     assert len(regs) == 2
     assert T_hat.shape == (15,)
     assert hasattr(clf, "predict_proba")
@@ -37,7 +37,7 @@ def test_em_learn_custom_models():
         X,
         Y,
         T,
-        n_treatments=3,
+        k=3,
         classifier_factory=clf_factory,
         regressor_factory=reg_factory,
         max_iter=2,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -27,7 +27,7 @@ def test_get_model_valid():
     model5 = get_model("gflownet_treatment", d_x=2, d_y=1)
     assert isinstance(model5, GFlowNetTreatment)
 
-    model6 = get_model("em", n_treatments=2)
+    model6 = get_model("em", k=2)
     assert isinstance(model6, EMModel)
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -24,7 +24,7 @@ def test_supervised_trainer_runs():
 def test_flow_model_runs():
     dataset = load_toy_dataset(n_samples=20, d_x=2, seed=1)
     loader = DataLoader(dataset, batch_size=5)
-    model = MixtureOfFlows(dim_x=2, dim_y=1, n_treat=2)
+    model = MixtureOfFlows(d_x=2, d_y=1, k=2)
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)


### PR DESCRIPTION
## Summary
- unify constructor arguments across models
- update MixtureOfFlows to accept `d_x`, `d_y`, and `k`
- rename `n_treatments` argument in EM model API to `k`
- adjust tests for new argument names

## Testing
- `ruff check --fix .`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2a1fe3bc832485af9f64d5b2ab14