### PR TITLE
Add gradient clipping support to trainers

### DIFF
--- a/xtylearner/training/diffusion.py
+++ b/xtylearner/training/diffusion.py
@@ -25,6 +25,7 @@ class DiffusionTrainer(BaseTrainer):
                 loss = self.step(batch)
                 self.optimizer.zero_grad()
                 loss.backward()
+                self._clip_grads()
                 self.optimizer.step()
                 if self.logger:
                     metrics = dict(self._metrics_from_loss(loss))

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -34,6 +34,7 @@ class GenerativeTrainer(BaseTrainer):
                 loss = self.step(batch)
                 self.optimizer.zero_grad()
                 loss.backward()
+                self._clip_grads()
                 self.optimizer.step()
                 if self.logger:
                     metrics = dict(self._metrics_from_loss(loss))

--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -35,6 +35,7 @@ class SupervisedTrainer(BaseTrainer):
                 loss = self.step(batch)
                 self.optimizer.zero_grad()
                 loss.backward()
+                self._clip_grads()
                 self.optimizer.step()
                 if self.logger:
                     metrics = dict(self._metrics_from_loss(loss))

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -23,10 +23,18 @@ class Trainer:
         device: str = "cpu",
         logger: Optional[TrainerLogger] = None,
         scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
+        grad_clip_norm: float | None = None,
     ) -> None:
         trainer_cls = self._select_trainer(model)
         self._trainer: BaseTrainer = trainer_cls(
-            model, optimizer, train_loader, val_loader, device, logger, scheduler
+            model,
+            optimizer,
+            train_loader,
+            val_loader,
+            device,
+            logger,
+            scheduler,
+            grad_clip_norm,
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- support gradient clipping via a new `grad_clip_norm` parameter
- apply clipping step in all training loops
- allow `Trainer` to forward the parameter

## Testing
- `ruff check xtylearner/training/base_trainer.py xtylearner/training/generative.py xtylearner/training/supervised.py xtylearner/training/diffusion.py xtylearner/training/trainer.py`
- `black xtylearner/training/base_trainer.py xtylearner/training/generative.py xtylearner/training/supervised.py xtylearner/training/diffusion.py xtylearner/training/trainer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3b31e73c83249225650096f312c1