### PR TITLE
Add EMTrainer for EM model

### DIFF
--- a/tests/test_em_trainer.py
+++ b/tests/test_em_trainer.py
@@ -1,0 +1,17 @@
+import torch
+from torch.utils.data import DataLoader
+
+from xtylearner.data import load_mixed_synthetic_dataset
+from xtylearner.models import get_model
+from xtylearner.training import Trainer
+
+
+def test_em_trainer_runs():
+    dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=0, label_ratio=0.5)
+    loader = DataLoader(dataset, batch_size=10)
+    model = get_model("em", k=2, max_iter=2)
+    opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -6,6 +6,7 @@ from .trainer import Trainer
 from .supervised import SupervisedTrainer
 from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
+from .em import EMTrainer
 from .metrics import (
     mse_loss,
     mae_loss,
@@ -19,6 +20,7 @@ __all__ = [
     "SupervisedTrainer",
     "GenerativeTrainer",
     "DiffusionTrainer",
+    "EMTrainer",
     "Trainer",
     "TrainerLogger",
     "ConsoleLogger",

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import torch
+
+from .base_trainer import BaseTrainer
+
+
+class EMTrainer(BaseTrainer):
+    """Trainer for :class:`~xtylearner.models.em_model.EMModel`."""
+
+    def _collect_arrays(
+        self, loader: Iterable
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        X_list, Y_list, T_list = [], [], []
+        for batch in loader:
+            x, y, t = self._extract_batch(batch)
+            X_list.append(x.cpu().numpy())
+            Y_list.append(y.squeeze(-1).cpu().numpy())
+            T_list.append(t.cpu().numpy())
+        X = np.concatenate(X_list, axis=0)
+        Y = np.concatenate(Y_list, axis=0)
+        T = np.concatenate(T_list, axis=0)
+        return X, Y, T
+
+    def fit(self, num_epochs: int) -> None:
+        X, Y, T_obs = self._collect_arrays(self.train_loader)
+        self.model.fit(X, Y, T_obs)
+
+    def evaluate(self, data_loader: Iterable) -> float:
+        X, Y, T_obs = self._collect_arrays(data_loader)
+        mask = T_obs != -1
+        if mask.sum() == 0:
+            return 0.0
+        probs = self.model.predict_treatment_proba(X[mask])
+        nll = -np.log(probs[np.arange(mask.sum()), T_obs[mask]] + 1e-12).mean()
+        return float(nll)
+
+    def predict(self, x: torch.Tensor, t_val: int):
+        X_np = x.cpu().numpy()
+        return self.model.predict_outcome(X_np, t_val)
+
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        X_np = x.cpu().numpy()
+        probs = self.model.predict_treatment_proba(X_np)
+        return torch.from_numpy(probs)
+
+
+__all__ = ["EMTrainer"]

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -8,6 +8,7 @@ from .base_trainer import BaseTrainer
 from .supervised import SupervisedTrainer
 from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
+from .em import EMTrainer
 from .logger import TrainerLogger
 
 
@@ -43,6 +44,8 @@ class Trainer:
             return GenerativeTrainer
         if hasattr(model, "sample") or hasattr(model, "paired_sample"):
             return DiffusionTrainer
+        if hasattr(model, "predict_outcome") and not hasattr(model, "train"):
+            return EMTrainer
         return SupervisedTrainer
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an `EMTrainer` for numpy-based EM models
- export new trainer in training package
- dispatch to `EMTrainer` in `Trainer` when models lack a `train` method
- test the EM trainer

## Testing
- `pre-commit run --files xtylearner/training/em.py xtylearner/training/__init__.py xtylearner/training/trainer.py tests/test_em_trainer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b42a041508324a2d49d4f589530a8