### PR TITLE
Fix EM trainer logging and remove sklearn warning

### DIFF
--- a/xtylearner/models/em_model.py
+++ b/xtylearner/models/em_model.py
@@ -37,9 +37,11 @@ def em_learn(
     if classifier_factory is None:
 
         def classifier_factory() -> LogisticRegression:
-            return LogisticRegression(
-                multi_class="multinomial", solver="lbfgs", max_iter=200
-            )
+            if k > 2:
+                return LogisticRegression(
+                    multi_class="multinomial", solver="lbfgs", max_iter=200
+                )
+            return LogisticRegression(max_iter=200)
 
     if regressor_factory is None:
 

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -27,7 +27,19 @@ class EMTrainer(BaseTrainer):
 
     def fit(self, num_epochs: int) -> None:
         X, Y, T_obs = self._collect_arrays(self.train_loader)
-        self.model.fit(X, Y, T_obs)
+        num_batches = len(self.train_loader)
+        for epoch in range(num_epochs):
+            if self.logger:
+                self.logger.start_epoch(epoch + 1, num_batches)
+            self.model.fit(X, Y, T_obs)
+            if self.logger:
+                metrics = self._treatment_metrics(
+                    torch.from_numpy(X),
+                    torch.from_numpy(Y).unsqueeze(-1),
+                    torch.from_numpy(T_obs),
+                )
+                self.logger.log_step(epoch + 1, num_batches - 1, num_batches, metrics)
+                self.logger.end_epoch(epoch + 1)
 
     def evaluate(self, data_loader: Iterable) -> float:
         X, Y, T_obs = self._collect_arrays(data_loader)


### PR DESCRIPTION
## Summary
- log training progress in `EMTrainer`
- avoid sklearn FutureWarning by selecting multinomial logistic regression only when needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4deda3048324ba27040eb80d916b