### PR TITLE
Implement EM model improvements

### DIFF
--- a/tests/test_em_model.py
+++ b/tests/test_em_model.py
@@ -18,10 +18,11 @@ def _generate_data(n=20, k=3, seed=0):
 
 def test_em_learn_default_runs():
     X, Y, T = _generate_data(n=15, k=2, seed=1)
-    clf, regs, s2, T_hat = em_learn(X, Y, T, k=2, max_iter=2)
+    clf, regs, s2, T_hat, ll = em_learn(X, Y, T, k=2, max_iter=2)
     assert len(regs) == 2
     assert T_hat.shape == (15,)
     assert hasattr(clf, "predict_proba")
+    assert isinstance(ll, float)
 
 
 def test_em_learn_custom_models():
@@ -33,7 +34,7 @@ def test_em_learn_custom_models():
     def reg_factory():
         return DecisionTreeRegressor(random_state=0)
 
-    clf, regs, s2, T_hat = em_learn(
+    clf, regs, s2, T_hat, ll = em_learn(
         X,
         Y,
         T,
@@ -45,3 +46,4 @@ def test_em_learn_custom_models():
     assert len(regs) == 3
     assert T_hat.shape == (10,)
     assert hasattr(clf, "predict_proba")
+    assert isinstance(ll, float)


### PR DESCRIPTION
## Summary
- use Y as an additional feature when fitting the treatment classifier
- return and store the complete-data log-likelihood
- update EM trainer to log the new metric and run one epoch
- adapt tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b522f5dd88324be76e52d5043bba9