### PR TITLE
Expose load_tabular_dataset in public API

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,8 +6,8 @@ from xtylearner.data import (
     load_toy_dataset,
     load_synthetic_dataset,
     load_mixed_synthetic_dataset,
-    load_tabular_dataset,
 )
+from xtylearner import load_tabular_dataset
 
 
 def test_load_toy_dataset_shapes():

--- a/xtylearner/__init__.py
+++ b/xtylearner/__init__.py
@@ -11,6 +11,7 @@ from .models import (
     LTFlowDiff,
     ProbCircuitModel,
 )
+from .data import load_tabular_dataset
 
 __all__ = [
     "CycleDual",
@@ -22,4 +23,5 @@ __all__ = [
     "BridgeDiff",
     "LTFlowDiff",
     "ProbCircuitModel",
+    "load_tabular_dataset",
 ]


### PR DESCRIPTION
## Summary
- make `load_tabular_dataset` accessible from the package root
- update dataset tests to import from the root package

## Testing
- `pre-commit run --files xtylearner/__init__.py tests/test_datasets.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5bb8ea5883248b6684191cbbf487