### PR TITLE
Add tabular dataloader example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ and ``"treatment"``).  When a NumPy array is provided ``outcome_col`` indicates
 how many outcome columns appear immediately before the treatment column.  All
 remaining columns are treated as covariates.
 
+Example usage with a ``DataLoader``:
+
+```python
+from xtylearner import load_tabular_dataset
+from torch.utils.data import DataLoader
+
+dataset = load_tabular_dataset("data.csv")
+loader = DataLoader(dataset, batch_size=32, shuffle=True)
+```
+
 ### Creating Models
 
 Model architectures register themselves with the module


### PR DESCRIPTION
## Summary
- show how to use `load_tabular_dataset` with a DataLoader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6bed6e6c8324b6264f8b3828733e