### PR TITLE
Fix CI venv build

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,14 +14,40 @@ jobs:
         fetch-depth: 1
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: |
           pyproject.toml
+          requirements.txt
+
+    - name: Restore venv
+      uses: actions/cache/restore@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-py3.11-${{ hashFiles('requirements.txt') }}
+
+    - name: Build venv if needed
+      if: steps.restore-venv.outputs.cache-hit != 'true'
+      env:
+        PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+      run: |
+        python -m venv .venv
+        . .venv/bin/activate
+        pip install -r requirements.txt
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
     - name: Install dependencies
+      env:
+        PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
       run: |
         python -m pip install --upgrade pip
+        pip install 'torch==2.3.1+cpu' -f https://download.pytorch.org/whl/cpu/torch_stable.html
         pip install -e . pytest pytest-xdist --prefer-binary
     - name: Run tests
       run: |
         pytest -vv -n auto
+
+    - name: Save venv
+      uses: actions/cache/save@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-py3.11-${{ hashFiles('requirements.txt') }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+torch==2.3.1+cpu
+scikit-learn==1.7.0
+numpy==2.3.1
+nflows==0.14
+pyyaml==6.0.2
+pandas==2.3.0
+pytest
+pytest-xdist


### PR DESCRIPTION
## Summary
- use Python 3.11 so requirements resolve
- update venv cache keys for Python 3.11

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b94670fe483248a5294f525b87ddf