### PR TITLE
Add label propagation model

### DIFF
--- a/docs/baselines/label_propagation.md
+++ b/docs/baselines/label_propagation.md
@@ -1,0 +1,126 @@
+Below is a self-contained primer you can drop straight into your repo’s docs/baselines/label_propagation.md.
+
+———
+
+1  Why bother with Label Propagation?
+•Manifold assumption. If points are close in input space, they probably share a label. A graph turns that intuition into a global smoothness constraint.
+•“Free” use of unlabelled rows. Unlike self-supervised pre-text methods that still require a supervised fine-tune, LP directly predicts labels for every unlabelled sample—often beating small neural nets when labels ≪ 1 000.
+•Computationally cheap. With a k-NN graph LP is O(k n) per iteration and converges in ≼ 20 iterations for typical tabular data; you can fit it in seconds with scikit-learn.
+•Interpretable upper bound. Because it ignores model capacity, LP tells reviewers “how far you can get just by exploiting geometry”.
+
+The algorithm traces back to Zhu & Ghahramani (2002) and its probabilistic reinterpretation as a Gaussian Random Field (Zhu, Ghahramani & Lafferty 2003)  👤 👤.
+
+———
+
+2  Theory in two equations
+1.Graph construction
+
+W_{ij}=k_\sigma(x_i,x_j)=\exp\!\Bigl(-\tfrac{\lVert x_i-x_j\rVert^{2}}{2\sigma^{2}}\Bigr)
+or a binary k-NN adjacency.
+Create the (row-)normalised similarity matrix
+
+S=D^{-1} W,\qquad D_{ii}=\sum_j W_{ij}.
+2.Harmonic energy minimisation
+
+Keep the label matrix Y\in\{0,1\}^{n\times C} fixed on labelled nodes \mathcal L and minimise
+
+\mathcal E(F)=\tfrac12\sum_{i,j} W_{ij}\lVert F_i-F_j\rVert^{2}\quad\text{s.t. }F_i=Y_i\,(i\!\in\!\mathcal L).
+
+The stationary solution satisfies the harmonic condition F_i=\sum_j S_{ij}F_j for unlabelled nodes. Rearranging yields the closed form
+
+F_{\mathcal U}=(I-S_{\mathcal UU})^{-1}S_{\mathcal UL}Y_{\mathcal L}.
+
+In practice scikit-learn iterates
+
+F^{(t+1)}=\alpha S F^{(t)}+(1-\alpha)Y,
+
+re-clamping the labelled rows each step; \alpha\!=\!1 gives Zhu’s original “Label Propagation”, 0<\alpha<1 gives “Label Spreading” (Zhou et al. 2004) that adds Laplacian smoothing.
+
+———
+
+3  Implementation guide
+
+3.1 Quick-start with scikit-learn
+
+```python
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+from sklearn.semi_supervised import LabelPropagation
+from sklearn.metrics import accuracy_score
+
+# X: (n_samples, n_features)  y: (n_samples,)
+# Unlabelled rows are marked with -1
+X, y = load_my_tabular_dataset()          # your helper
+mask_unl = y == -1                        # boolean mask
+
+X_scaled = StandardScaler().fit_transform(X)   # important for RBF
+
+lp = LabelPropagation(kernel='knn',       # or 'rbf'
+                      n_neighbors=10,     # ignored if kernel='rbf'
+                      gamma=20,           # RBF bandwidth; ignored for knn
+                      max_iter=1000, tol=1e-3)
+
+lp.fit(X_scaled, y)
+
+y_full = lp.transduction_                 # labels for *all* rows
+y_unl_pred = y_full[mask_unl]
+
+print("Propagated", mask_unl.sum(), "labels")
+print("Accuracy on held-out labelled set:",
+      accuracy_score(y_holdout_true, y_full[y_holdout_idx]))
+```
+
+Tip: for categorical columns, one-hot before scaling, or use a distance metric that respects category mismatches (e.g. Hamming + numeric Mahalanobis) and pass a callable kernel to LabelPropagation.
+
+3.2 Hyperparameter heuristics
+
+ParameterDefaultWhen to change
+kernel='rbf'good for dense, low-dim dataswitch to 'knn' when features have mixed scales or p ≫ 30
+gamma (RBF)20set to 1/(2\sigma^{2}). Cross-validate over log-space  [10^{-2},10^{3}].
+n_neighbors (k-NN)7rule-of-thumb: \sqrt{n} for small n; decay to n^{1/3} for big n.
+alpha (LabelSpreading only)0.2bigger = stronger clamping; 0.1–0.3 usually works.
+
+3.3 Scaling to large tables
+•Build the k-NN graph with FAISS or Annoy and hand it to scikit-learn via a sparse affinity matrix.
+•Use the efficient LP solver of Fujiwara & Iruka 2014 to avoid the O(n^{3}) inverse  👤.
+•Batch over disconnected components to fit into memory.
+
+3.4 Packaging for XTYLearner
+
+```python
+# xtylearner/models/labelprop.py
+from sklearn.semi_supervised import LabelPropagation
+from .registry import register_model
+
+@register_model("lp_knn")
+class LP_KNN:
+    def __init__(self, n_neighbors=10):
+        self.clf = LabelPropagation(kernel="knn", n_neighbors=n_neighbors)
+
+    def fit(self, X, y):
+        self.clf.fit(X, y)      # y uses -1 for unlabelled
+        return self
+
+    def predict(self, X):
+        return self.clf.predict(X)
+
+    def predict_proba(self, X):
+        return self.clf.predict_proba(X)
+```
+
+Now a one-line call in your training script:
+
+```python
+model = models.build_model("lp_knn", n_neighbors=15).fit(X_train, y_train)
+```
+
+———
+
+4  Further reading
+•Zhu & Ghahramani, “Learning from Labeled and Unlabeled Data with Label Propagation”, CMU Tech Rep 2002.  👤
+•Zhu, Ghahramani & Lafferty, “Semi-Supervised Learning Using Gaussian Fields and Harmonic Functions”, ICML 2003.  👤
+•Fujiwara & Iruka, “Efficient Label Propagation”, JMLR 2014.  👤
+•scikit-learn LabelPropagation docs (examples, API).  👤
+
+With those few dozen lines you have a rock-solid classical baseline that costs almost nothing to maintain yet often gives surprisingly strong numbers on UCI-style tables.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,6 +18,7 @@ from xtylearner.models import (
     M2VAE,
     MultiTask,
     ProbCircuitModel,
+    LP_KNN,
     SS_CEVAE,
 )
 
@@ -40,6 +41,7 @@ from xtylearner.models import (
         ("jsbf", JSBF, {"d_x": 2, "d_y": 1}),
         ("masked_tabular_transformer", MaskedTabularTransformer, {"d_x": 2}),
         ("prob_circuit", ProbCircuitModel, {}),
+        ("lp_knn", LP_KNN, {}),
     ],
 )
 def test_get_model_valid(name, cls, kwargs):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -7,7 +7,7 @@ from xtylearner.training import Trainer
 from xtylearner.models import M2VAE, SS_CEVAE, JSBF, DiffusionCEVAE
 from xtylearner.models import BridgeDiff, LTFlowDiff
 from xtylearner.models import EnergyDiffusionImputer, JointEBM, GFlowNetTreatment
-from xtylearner.models import ProbCircuitModel
+from xtylearner.models import ProbCircuitModel, LP_KNN
 
 
 def test_supervised_trainer_runs():
@@ -203,3 +203,14 @@ def test_trainer_handles_model_without_to():
     opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
     trainer = Trainer(model, opt, loader)
     assert trainer.model is model
+
+
+def test_labelprop_trainer_runs():
+    dataset = load_toy_dataset(n_samples=20, d_x=2, seed=16)
+    loader = DataLoader(dataset, batch_size=5)
+    model = LP_KNN(n_neighbors=3)
+    opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+    acc = trainer.evaluate(loader)
+    assert isinstance(acc, float)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -13,6 +13,7 @@ from .prob_circuit_model import ProbCircuitModel
 from .masked_tabular_transformer import MaskedTabularTransformer
 from .gflownet_treatment import GFlowNetTreatment
 from .em_model import EMModel
+from .labelprop import LP_KNN
 from .registry import get_model, get_model_names, get_model_args
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "ProbCircuitModel",
     "GFlowNetTreatment",
     "EMModel",
+    "LP_KNN",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/labelprop.py
+++ b/xtylearner/models/labelprop.py
@@ -1,0 +1,43 @@
+"""Lightweight wrapper around scikit-learn's :class:`LabelPropagation`."""
+
+from __future__ import annotations
+
+from sklearn.semi_supervised import LabelPropagation
+
+from .registry import register_model
+
+
+@register_model("lp_knn")
+class LP_KNN:
+    """k-NN label propagation baseline.
+
+    The model propagates *treatment* labels through an affinity graph.  It can
+    be used with :class:`~xtylearner.training.ArrayTrainer`, which will pass the
+    observed treatment column as the target argument.  For compatibility with the
+    registry, the ``fit`` method also accepts datasets without an explicit
+    treatment column and will fall back to the provided ``y`` labels.
+    """
+
+    # ``target`` tells :class:`~ArrayTrainer` to use the treatment column.
+    target = "treatment"
+    requires_outcome = False
+
+    def __init__(self, n_neighbors: int = 10):
+        self.clf = LabelPropagation(kernel="knn", n_neighbors=n_neighbors)
+
+    # ------------------------------------------------------------------
+    def fit(self, X, y, t_obs=None):
+        target = t_obs if t_obs is not None else y
+        self.clf.fit(X, target)
+        return self
+
+    # ------------------------------------------------------------------
+    def predict(self, X):
+        return self.clf.predict(X)
+
+    # ------------------------------------------------------------------
+    def predict_proba(self, X):
+        return self.clf.predict_proba(X)
+
+    # ``ArrayTrainer`` looks for this method when computing metrics.
+    predict_treatment_proba = predict_proba

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -6,7 +6,7 @@ from .trainer import Trainer
 from .supervised import SupervisedTrainer
 from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
-from .em import EMTrainer
+from .em import ArrayTrainer, EMTrainer
 from .metrics import (
     mse_loss,
     mae_loss,
@@ -20,6 +20,7 @@ __all__ = [
     "SupervisedTrainer",
     "GenerativeTrainer",
     "DiffusionTrainer",
+    "ArrayTrainer",
     "EMTrainer",
     "Trainer",
     "TrainerLogger",

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -8,8 +8,15 @@ import torch
 from .base_trainer import BaseTrainer
 
 
-class EMTrainer(BaseTrainer):
-    """Trainer for :class:`~xtylearner.models.em_model.EMModel`."""
+class ArrayTrainer(BaseTrainer):
+    """Trainer for array-based models with a ``fit`` method.
+
+    This generalises the previous :class:`EMTrainer` used for the EM baseline
+    so that any model exposing a ``fit`` method operating on NumPy arrays can be
+    trained.  It works with datasets providing ``(X, Y)`` pairs as well as
+    ``(X, Y, T)`` triples – the latter will be passed to the model only if its
+    ``fit`` signature accepts a treatment argument.
+    """
 
     def _collect_arrays(
         self, loader: Iterable
@@ -30,7 +37,16 @@ class EMTrainer(BaseTrainer):
         num_batches = len(self.train_loader)
         if self.logger:
             self.logger.start_epoch(1, num_batches)
-        self.model.fit(X, Y, T_obs)
+        import inspect
+
+        fit_sig = inspect.signature(self.model.fit)
+        params = [p.name for p in fit_sig.parameters.values() if p.name != "self"]
+        use_t = getattr(self.model, "target", "outcome") == "treatment"
+        if len(params) >= 3:
+            self.model.fit(X, Y, T_obs)
+        else:
+            target = T_obs if use_t else Y
+            self.model.fit(X, target)
         if self.logger:
             metrics = self._treatment_metrics(
                 torch.from_numpy(X),
@@ -49,24 +65,38 @@ class EMTrainer(BaseTrainer):
 
     def evaluate(self, data_loader: Iterable) -> float:
         X, Y, T_obs = self._collect_arrays(data_loader)
-        mask = T_obs != -1
-        if mask.sum() == 0:
-            return 0.0
-        Z = np.concatenate([X[mask], Y[mask, None]], axis=1)
-        probs = self.model.predict_treatment_proba(Z)
-        nll = -np.log(probs[np.arange(mask.sum()), T_obs[mask]] + 1e-12).mean()
-        return float(nll)
+        if hasattr(self.model, "predict_treatment_proba"):
+            mask = T_obs != -1
+            if mask.sum() == 0:
+                return 0.0
+            if getattr(self.model, "requires_outcome", True):
+                Z = np.concatenate([X[mask], Y[mask, None]], axis=1)
+            else:
+                Z = X[mask]
+            probs = self.model.predict_treatment_proba(Z)
+            nll = -np.log(probs[np.arange(mask.sum()), T_obs[mask]] + 1e-12).mean()
+            return float(nll)
+        preds = self.model.predict(X)
+        target = T_obs if getattr(self.model, "target", "outcome") == "treatment" else Y
+        return float((preds == target).mean())
 
-    def predict(self, x: torch.Tensor, t_val: int):
+    def predict(self, x: torch.Tensor, t_val: int | None = None):
         X_np = x.cpu().numpy()
-        return self.model.predict_outcome(X_np, t_val)
+        if t_val is not None and hasattr(self.model, "predict_outcome"):
+            return self.model.predict_outcome(X_np, t_val)
+        return self.model.predict(X_np)
 
     def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         X_np = x.cpu().numpy()
-        y_np = y.squeeze(-1).cpu().numpy()
-        Z = np.concatenate([X_np, y_np[:, None]], axis=1)
+        if getattr(self.model, "requires_outcome", True):
+            y_np = y.squeeze(-1).cpu().numpy()
+            Z = np.concatenate([X_np, y_np[:, None]], axis=1)
+        else:
+            Z = X_np
         probs = self.model.predict_treatment_proba(Z)
         return torch.from_numpy(probs)
 
 
-__all__ = ["EMTrainer"]
+EMTrainer = ArrayTrainer
+
+__all__ = ["ArrayTrainer", "EMTrainer"]

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -8,7 +8,7 @@ from .base_trainer import BaseTrainer
 from .supervised import SupervisedTrainer
 from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
-from .em import EMTrainer
+from .em import ArrayTrainer
 from .logger import TrainerLogger
 
 
@@ -45,7 +45,13 @@ class Trainer:
         if hasattr(model, "sample") or hasattr(model, "paired_sample"):
             return DiffusionTrainer
         if hasattr(model, "predict_outcome") and not hasattr(model, "train"):
-            return EMTrainer
+            return ArrayTrainer
+        if (
+            hasattr(model, "fit")
+            and not hasattr(model, "loss")
+            and not hasattr(model, "train")
+        ):
+            return ArrayTrainer
         return SupervisedTrainer
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- implement scikit-learn label propagation baseline
- generalise EMTrainer into ArrayTrainer for numpy-based models
- wire up trainer dispatch logic for ArrayTrainer
- document label propagation in `docs/baselines`
- add unit tests for new model and trainer
- fix label propagation trainer support

## Testing
- `pre-commit run --files xtylearner/models/labelprop.py xtylearner/training/em.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b8d622a748324b361a10f4726e1bd