### PR TITLE
Fix MeanTeacher consistency weight computation

### DIFF
--- a/docs/baselines/mean_teacher.md
+++ b/docs/baselines/mean_teacher.md
@@ -85,6 +85,7 @@ Use different noise for student and teacher views; that is what gives the consis
 ```python
 # xtylearner/models/mean_teacher.py
 from copy import deepcopy
+import math
 import torch, torch.nn as nn
 from .registry import register_model
 
@@ -104,7 +105,7 @@ class MeanTeacher(nn.Module):
 
     def _consistency_weight(self, epoch):
         t = min(epoch / self.ramp_up, 1.0)
-        return self.cons_max * torch.exp(-5 * (1 - t) ** 2)
+        return self.cons_max * math.exp(-5 * (1 - t) ** 2)
 
     def forward(self, x, teacher=False):
         net = self.teacher if teacher else self.student

--- a/xtylearner/models/mean_teacher.py
+++ b/xtylearner/models/mean_teacher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 
+import math
 import torch
 import torch.nn as nn
 
@@ -33,7 +34,7 @@ class MeanTeacher(nn.Module):
     # --------------------------------------------------------------
     def _consistency_weight(self, epoch: int) -> torch.Tensor:
         t = min(epoch / self.ramp_up, 1.0)
-        return self.cons_max * torch.exp(-5 * (1 - t) ** 2)
+        return self.cons_max * math.exp(-5 * (1 - t) ** 2)
 
     # --------------------------------------------------------------
     def forward(self, x: torch.Tensor, teacher: bool = False) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- fix MeanTeacher to use `math.exp` for consistency weight
- update documentation snippet accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c402b60108324bee80206f688a83d