### PR TITLE
Fix missing SciPy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "nflows",
     "pyyaml",
     "pandas",
+    "scipy",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ numpy==2.3.1
 nflows==0.14
 pyyaml==6.0.2
 pandas==2.3.0
+scipy==1.16.0
 pytest
 pytest-xdist


### PR DESCRIPTION
## Summary
- add missing SciPy package used by `EMModel` to `requirements.txt`
- list SciPy in `pyproject.toml` project dependencies

## Testing
- `ruff check xtylearner tests --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c409ef7d48324b545dd5f8d10fe1f