### PR TITLE
Remove unused lr parameter from EnergyDiffusionImputer

### DIFF
--- a/xtylearner/models/energy_diffusion_imputer.py
+++ b/xtylearner/models/energy_diffusion_imputer.py
@@ -75,7 +75,6 @@ class EnergyDiffusionImputer(nn.Module):
         *,
         timesteps: int = 1000,
         hidden: int = 128,
-        lr: float = 2e-4,
         k: int = 2,
     ) -> None:
         super().__init__()


### PR DESCRIPTION
## Summary
- remove the unused `lr` argument from `EnergyDiffusionImputer.__init__`

## Testing
- `ruff check xtylearner/models/energy_diffusion_imputer.py`
- `black xtylearner/models/energy_diffusion_imputer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c40c340c48324be423104178b2fdf