### PR TITLE
Fix GPU-only FixMatch usage

### DIFF
--- a/docs/baselines/fixmatch.md
+++ b/docs/baselines/fixmatch.md
@@ -131,7 +131,8 @@ class FixMatch:
 
     def predict_proba(self, X):
         import torch, torch.nn.functional as F
-        X = torch.tensor(X, dtype=torch.float32).cuda()
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        X = torch.tensor(X, dtype=torch.float32).to(device)
         with torch.no_grad():
             return F.softmax(self.net(X), 1).cpu().numpy()
 

--- a/xtylearner/models/fixmatch_tabular.py
+++ b/xtylearner/models/fixmatch_tabular.py
@@ -47,9 +47,12 @@ def train_fixmatch(
     tau: float = 0.95,
     lambda_u: float = 1.0,
     lr: float = 3e-4,
-    device: str = "cuda",
+    device: str | None = None,
 ) -> None:
     """Train ``model`` with FixMatch."""
+
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
 
     opt = torch.optim.AdamW(model.parameters(), lr)
     it_unlab = iter(loader_unlab)
@@ -74,5 +77,3 @@ def train_fixmatch(
             opt.zero_grad()
             loss.backward()
             opt.step()
-
-


### PR DESCRIPTION
## Summary
- handle CUDA availability in FixMatch wrapper and training utils
- update FixMatch documentation with device guard

## Testing
- `ruff check --fix xtylearner/models/fixmatch.py xtylearner/models/fixmatch_tabular.py`
- `black xtylearner/models/fixmatch.py xtylearner/models/fixmatch_tabular.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686c40710b8c8324ab8d72b0f13afd2d