### PR TITLE
Fix variable shadowing in diffusion models

### DIFF
--- a/xtylearner/models/bridge_diff.py
+++ b/xtylearner/models/bridge_diff.py
@@ -140,8 +140,8 @@ class BridgeDiff(nn.Module):
         device = x.device
         y = torch.randn(b, self.k, self.d_y, device=device) * self.sigma_max
 
-        for k in reversed(range(1, n_steps + 1)):
-            tau = torch.full((b, 1), k / n_steps, device=device)
+        for step_idx in reversed(range(1, n_steps + 1)):
+            tau = torch.full((b, 1), step_idx / n_steps, device=device)
             sig = self._sigma(tau)
             for t_val in range(self.k):
                 score = self.score_net(
@@ -151,7 +151,7 @@ class BridgeDiff(nn.Module):
                     tau,
                 )
                 y[:, t_val] = y[:, t_val] + (sig**2) * score
-            if k > 1:
+            if step_idx > 1:
                 prev = tau - 1 / n_steps
                 noise_scale = (sig**2 - self._sigma(prev).pow(2)).sqrt()
                 noise = torch.randn_like(y[:, 0])

--- a/xtylearner/models/lt_flow_diff.py
+++ b/xtylearner/models/lt_flow_diff.py
@@ -130,6 +130,7 @@ class Classifier(nn.Module):
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         return self.net(torch.cat([x, y], dim=-1))
 
+
 @register_model("lt_flow_diff")
 class LTFlowDiff(nn.Module):
     """Latent-Treatment Flow Diffusion model."""
@@ -181,8 +182,8 @@ class LTFlowDiff(nn.Module):
         )
 
         b = x.size(0)
-        k = torch.randint(1, self.timesteps + 1, (b,), device=device)
-        tau = k.float() / self.timesteps
+        t_idx = torch.randint(1, self.timesteps + 1, (b,), device=device)
+        tau = t_idx.float() / self.timesteps
         sig = self._sigma(tau).unsqueeze(-1)
         noise = torch.randn_like(z)
         z_tau = z + sig * noise


### PR DESCRIPTION
## Summary
- fix confusing variable shadowing where local `k` time step index masked model attribute `self.k`
- update loops and computations to use clearer names like `t_idx` and `step_idx`

## Testing
- `pre-commit run --files xtylearner/models/lt_flow_diff.py xtylearner/models/energy_diffusion_imputer.py xtylearner/models/bridge_diff.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c480a6d8083248b426ce9d061e2a8