### PR TITLE
Improve VAT multi-target support

### DIFF
--- a/tests/test_vat_model.py
+++ b/tests/test_vat_model.py
@@ -1,0 +1,13 @@
+import torch
+
+from xtylearner.models import VAT_Model
+
+
+def test_vat_supports_multitarget():
+    X_lab = torch.randn(4, 3)
+    y_lab = torch.randint(0, 2, (4, 2))
+    X_unlab = torch.randn(6, 3)
+    model = VAT_Model()
+    model.fit(X_lab, y_lab, X_unlab, epochs=1, bs=2)
+    out = model.predict_proba(torch.randn(3, 3))
+    assert out.shape == (3, 2)


### PR DESCRIPTION
## Summary
- update VAT_Model to support multi-target labels using BCE loss
- adjust `predict_proba`/`predict` to handle multilabel mode
- add regression test for VAT with multi-target labels

## Testing
- `pytest tests/test_vat_model.py::test_vat_supports_multitarget -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6218ac7083249165d9693d7e894e