### PR TITLE
Add validation metrics logging

### DIFF
--- a/xtylearner/training/diffusion.py
+++ b/xtylearner/training/diffusion.py
@@ -34,18 +34,15 @@ class DiffusionTrainer(BaseTrainer):
                     self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
             if self.scheduler is not None:
                 self.scheduler.step()
+            if self.logger and self.val_loader is not None:
+                val_metrics = self._eval_metrics(self.val_loader)
+                self.logger.log_validation(epoch + 1, val_metrics)
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
     def evaluate(self, data_loader: Iterable) -> float:
-        self.model.eval()
-        total, n = 0.0, 0
-        with torch.no_grad():
-            for batch in data_loader:
-                loss = self.step(batch)
-                total += float(loss.item()) * len(batch[0])
-                n += len(batch[0])
-        return total / max(n, 1)
+        metrics = self._eval_metrics(data_loader)
+        return metrics.get("loss", next(iter(metrics.values()), 0.0))
 
     def predict(self, n: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         self.model.eval()

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -61,6 +61,21 @@ class ArrayTrainer(BaseTrainer):
                 )
             )
             self.logger.log_step(1, num_batches - 1, num_batches, metrics)
+            if self.val_loader is not None:
+                Xv, Yv, Tv = self._collect_arrays(self.val_loader)
+                val_metrics = self._treatment_metrics(
+                    torch.from_numpy(Xv),
+                    torch.from_numpy(Yv).unsqueeze(-1),
+                    torch.from_numpy(Tv),
+                )
+                val_metrics.update(
+                    self._outcome_metrics(
+                        torch.from_numpy(Xv),
+                        torch.from_numpy(Yv).unsqueeze(-1),
+                        torch.from_numpy(Tv),
+                    )
+                )
+                self.logger.log_validation(1, val_metrics)
             self.logger.end_epoch(1)
 
     def _treatment_metrics(

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -43,18 +43,15 @@ class GenerativeTrainer(BaseTrainer):
                     self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
             if self.scheduler is not None:
                 self.scheduler.step()
+            if self.logger and self.val_loader is not None:
+                val_metrics = self._eval_metrics(self.val_loader)
+                self.logger.log_validation(epoch + 1, val_metrics)
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
     def evaluate(self, data_loader: Iterable) -> float:
-        self.model.eval()
-        total, n = 0.0, 0
-        with torch.no_grad():
-            for batch in data_loader:
-                loss = self.step(batch)
-                total += float(loss.item()) * len(batch[0])
-                n += len(batch[0])
-        return total / max(n, 1)
+        metrics = self._eval_metrics(data_loader)
+        return metrics.get("loss", next(iter(metrics.values()), 0.0))
 
     def predict(self, x: torch.Tensor, t_val: int) -> torch.Tensor:
         self.model.eval()

--- a/xtylearner/training/logger.py
+++ b/xtylearner/training/logger.py
@@ -40,6 +40,10 @@ class TrainerLogger(ABC):
     ) -> None:
         """Log metrics for a single step."""
 
+    @abstractmethod
+    def log_validation(self, epoch: int, metrics: Mapping[str, float]) -> None:
+        """Log validation metrics at the end of an epoch."""
+
     def end_epoch(self, epoch: int) -> None:
         """Log average metrics at the end of an epoch."""
 
@@ -67,3 +71,7 @@ class ConsoleLogger(TrainerLogger):
                 end=end,
                 flush=True,
             )
+
+    def log_validation(self, epoch: int, metrics: Mapping[str, float]) -> None:
+        metric_str = ", ".join(f"{k}={v:.4f}" for k, v in metrics.items())
+        print(f"Epoch {epoch} validation: {metric_str}")


### PR DESCRIPTION
## Summary
- log validation stats through `TrainerLogger`
- support validation metric reporting in ConsoleLogger
- compute validation metrics in base trainer and trainers

## Testing
- `pre-commit run --files xtylearner/training/logger.py xtylearner/training/base_trainer.py xtylearner/training/supervised.py xtylearner/training/generative.py xtylearner/training/diffusion.py xtylearner/training/em.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6ea55c608324922404a7fdb7cd14