### PR TITLE
Refactor VIME modules to use shared MLP utilities

### DIFF
--- a/tests/test_vime_model.py
+++ b/tests/test_vime_model.py
@@ -1,0 +1,13 @@
+import torch
+
+from xtylearner.models import VIME_Model
+
+
+def test_vime_basic_training():
+    X_lab = torch.randn(4, 3)
+    y_lab = torch.randint(0, 2, (4, 2))
+    X_unlab = torch.randn(6, 3)
+    model = VIME_Model()
+    model.fit(X_lab, y_lab, X_unlab, pre_epochs=1, pre_bs=2, sl_epochs=1, sl_bs=2)
+    out = model.predict_proba(torch.randn(3, 3))
+    assert out.shape == (3, 2)

--- a/xtylearner/models/vime.py
+++ b/xtylearner/models/vime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import torch
+import torch.nn as nn
+from typing import Callable
 
 from .registry import register_model
 from .vime_self_pt import train_vime_s
@@ -11,13 +13,48 @@ from .vime_semi_pt import train_vime_sl
 class VIME_Model:
     """Wrapper that trains the two-stage VIME algorithm."""
 
-    def __init__(self, p_m: float = 0.3, alpha: float = 2.0, K: int = 3, beta: float = 10.0) -> None:
+    def __init__(
+        self,
+        p_m: float = 0.3,
+        alpha: float = 2.0,
+        K: int = 3,
+        beta: float = 10.0,
+        *,
+        hidden_dims: tuple[int, ...] | list[int] = (128, 128),
+        activation: type[nn.Module] = nn.ReLU,
+        dropout: float | None = None,
+        norm_layer: Callable[[int], nn.Module] | None = None,
+    ) -> None:
         self.cfg = {"p_m": p_m, "alpha": alpha, "K": K, "beta": beta}
-        self.clf = None
+        self.hidden_dims = tuple(hidden_dims)
+        self.activation = activation
+        self.dropout = dropout
+        self.norm_layer = norm_layer
+        self.clf: nn.Module | None = None
 
     # --------------------------------------------------------------
-    def fit(self, X_lab, y_lab, X_unlab):
-        enc = train_vime_s(X_unlab, p_m=self.cfg["p_m"], alpha=self.cfg["alpha"])
+    def fit(
+        self,
+        X_lab,
+        y_lab,
+        X_unlab,
+        *,
+        pre_epochs: int = 50,
+        pre_bs: int = 256,
+        sl_epochs: int = 200,
+        sl_bs: int = 128,
+    ) -> "VIME_Model":
+        enc = train_vime_s(
+            X_unlab,
+            p_m=self.cfg["p_m"],
+            alpha=self.cfg["alpha"],
+            epochs=pre_epochs,
+            bs=pre_bs,
+            hidden_dims=self.hidden_dims,
+            activation=self.activation,
+            dropout=self.dropout,
+            norm_layer=self.norm_layer,
+        )
         self.clf = train_vime_sl(
             enc,
             X_lab,
@@ -25,6 +62,13 @@ class VIME_Model:
             X_unlab,
             K=self.cfg["K"],
             beta=self.cfg["beta"],
+            p_m=self.cfg["p_m"],
+            epochs=sl_epochs,
+            bs=sl_bs,
+            hidden_dims=self.hidden_dims,
+            activation=self.activation,
+            dropout=self.dropout,
+            norm_layer=self.norm_layer,
         )
         return self
 

--- a/xtylearner/models/vime_semi_pt.py
+++ b/xtylearner/models/vime_semi_pt.py
@@ -3,17 +3,34 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from typing import Callable
 
+from .layers import make_mlp
 from .vime_self_pt import Encoder, mask_corrupt
 
 
 class Classifier(nn.Module):
-    """Classifier head on top of a frozen VIME encoder."""
+    """Classifier head on top of a VIME encoder."""
 
-    def __init__(self, enc: Encoder, out_dim: int) -> None:
+    def __init__(
+        self,
+        enc: Encoder,
+        out_dim: int,
+        *,
+        hidden_dims: tuple[int, ...] | list[int] = (),
+        activation: type[nn.Module] = nn.ReLU,
+        dropout: float | None = None,
+        norm_layer: Callable[[int], nn.Module] | None = None,
+    ) -> None:
         super().__init__()
         self.enc = enc
-        self.head = nn.Linear(enc.net[-2].out_features, out_dim)
+        dims = [enc.out_dim, *hidden_dims, out_dim]
+        self.head = make_mlp(
+            dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.head(self.enc(x))
@@ -27,23 +44,36 @@ def train_vime_sl(
     *,
     K: int = 3,
     beta: float = 10.0,
+    p_m: float = 0.3,
     epochs: int = 200,
     bs: int = 128,
+    hidden_dims: tuple[int, ...] | list[int] = (),
+    activation: type[nn.Module] = nn.ReLU,
+    dropout: float | None = None,
+    norm_layer: Callable[[int], nn.Module] | None = None,
+    lr: float = 3e-4,
 ) -> Classifier:
     """Semi-supervised fine-tuning of a VIME encoder."""
 
     Xl = torch.as_tensor(X_lab, dtype=torch.float32)
     yl = torch.as_tensor(y_lab, dtype=torch.float32)
     Xu = torch.as_tensor(X_unlab, dtype=torch.float32)
-    clf = Classifier(enc, yl.shape[1])
-    opt = optim.Adam(clf.parameters(), 3e-4)
+    clf = Classifier(
+        enc,
+        yl.shape[1],
+        hidden_dims=hidden_dims,
+        activation=activation,
+        dropout=dropout,
+        norm_layer=norm_layer,
+    )
+    opt = optim.Adam(clf.parameters(), lr)
     ce, mse = nn.CrossEntropyLoss(), nn.MSELoss()
     for _ in range(epochs):
         idx = torch.randint(0, len(Xl), (bs,))
         x_l, y_l = Xl[idx], yl[idx]
         idx_u = torch.randint(0, len(Xu), (bs,))
         x_u = Xu[idx_u]
-        x_u_k = torch.stack([mask_corrupt(x_u, p_m=0.3)[1] for _ in range(K)])
+        x_u_k = torch.stack([mask_corrupt(x_u, p_m=p_m)[1] for _ in range(K)])
         logits_l = clf(x_l)
         sup = ce(logits_l, y_l.argmax(1))
         logits_u = clf(x_u_k.view(-1, x_u.shape[1])).view(K, bs, -1)


### PR DESCRIPTION
## Summary
- refactor vime modules to use `make_mlp`
- expose architecture parameters in VIME model
- update training loops to accept common settings
- add regression test for VIME training

## Testing
- `ruff check .`
- `black xtylearner/models/vime.py xtylearner/models/vime_self_pt.py xtylearner/models/vime_semi_pt.py tests/test_vime_model.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7223e6088324aba8ccbdea83ed24