### PR TITLE
Refactor VIME into single-stage trainer module

### DIFF
--- a/tests/test_vime_model.py
+++ b/tests/test_vime_model.py
@@ -1,13 +1,24 @@
 import torch
+from torch.utils.data import DataLoader, TensorDataset
 
-from xtylearner.models import VIME_Model
+from xtylearner.models import VIME
+from xtylearner.training import Trainer
 
 
 def test_vime_basic_training():
     X_lab = torch.randn(4, 3)
-    y_lab = torch.randint(0, 2, (4, 2))
+    y_lab = torch.randint(0, 2, (4,), dtype=torch.long)
     X_unlab = torch.randn(6, 3)
-    model = VIME_Model()
-    model.fit(X_lab, y_lab, X_unlab, pre_epochs=1, pre_bs=2, sl_epochs=1, sl_bs=2)
+
+    model = VIME(d_x=3, out_dim=2)
+
+    X_train = torch.cat([X_lab, X_unlab])
+    y_train = torch.cat([y_lab, torch.full((6,), -1)])
+    loader = DataLoader(TensorDataset(X_train, y_train), batch_size=2, shuffle=True)
+
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+
     out = model.predict_proba(torch.randn(3, 3))
     assert out.shape == (3, 2)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -15,7 +15,7 @@ from .gflownet_treatment import GFlowNetTreatment
 from .em_model import EMModel
 from .labelprop import LP_KNN
 from .mean_teacher import MeanTeacher
-from .vime import VIME_Model
+from .vime import VIME
 from .vat import VAT_Model
 from .fixmatch import FixMatch
 from .registry import get_model, get_model_names, get_model_args
@@ -38,7 +38,7 @@ __all__ = [
     "EMModel",
     "LP_KNN",
     "MeanTeacher",
-    "VIME_Model",
+    "VIME",
     "VAT_Model",
     "FixMatch",
     "get_model",

--- a/xtylearner/models/vime.py
+++ b/xtylearner/models/vime.py
@@ -2,83 +2,119 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from typing import Callable
 
 from .registry import register_model
-from .vime_self_pt import train_vime_s
-from .vime_semi_pt import train_vime_sl
+from .layers import make_mlp
+from .vime_self_pt import Encoder, Decoder, mask_corrupt
 
 
 @register_model("vime")
-class VIME_Model:
-    """Wrapper that trains the two-stage VIME algorithm."""
+class VIME(nn.Module):
+    """Two-stage VIME model with trainer-friendly interface."""
 
     def __init__(
         self,
+        d_x: int,
+        out_dim: int,
+        *,
         p_m: float = 0.3,
         alpha: float = 2.0,
         K: int = 3,
         beta: float = 10.0,
-        *,
         hidden_dims: tuple[int, ...] | list[int] = (128, 128),
         activation: type[nn.Module] = nn.ReLU,
         dropout: float | None = None,
         norm_layer: Callable[[int], nn.Module] | None = None,
     ) -> None:
-        self.cfg = {"p_m": p_m, "alpha": alpha, "K": K, "beta": beta}
-        self.hidden_dims = tuple(hidden_dims)
-        self.activation = activation
-        self.dropout = dropout
-        self.norm_layer = norm_layer
-        self.clf: nn.Module | None = None
+        super().__init__()
+        self.p_m = p_m
+        self.alpha = alpha
+        self.K = K
+        self.beta = beta
 
-    # --------------------------------------------------------------
-    def fit(
-        self,
-        X_lab,
-        y_lab,
-        X_unlab,
-        *,
-        pre_epochs: int = 50,
-        pre_bs: int = 256,
-        sl_epochs: int = 200,
-        sl_bs: int = 128,
-    ) -> "VIME_Model":
-        enc = train_vime_s(
-            X_unlab,
-            p_m=self.cfg["p_m"],
-            alpha=self.cfg["alpha"],
-            epochs=pre_epochs,
-            bs=pre_bs,
-            hidden_dims=self.hidden_dims,
-            activation=self.activation,
-            dropout=self.dropout,
-            norm_layer=self.norm_layer,
+        self.encoder = Encoder(
+            d_x,
+            hidden_dims=hidden_dims,
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
         )
-        self.clf = train_vime_sl(
-            enc,
-            X_lab,
-            y_lab,
-            X_unlab,
-            K=self.cfg["K"],
-            beta=self.cfg["beta"],
-            p_m=self.cfg["p_m"],
-            epochs=sl_epochs,
-            bs=sl_bs,
-            hidden_dims=self.hidden_dims,
-            activation=self.activation,
-            dropout=self.dropout,
-            norm_layer=self.norm_layer,
+        self.decoder = Decoder(
+            d_x,
+            self.encoder.out_dim,
+            hidden_dims=(),
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
         )
-        return self
+        self.classifier = make_mlp(
+            [self.encoder.out_dim, *hidden_dims, out_dim],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
 
     # --------------------------------------------------------------
-    def predict_proba(self, X):
-        X = torch.as_tensor(X, dtype=torch.float32)
-        with torch.no_grad():
-            out = self.clf(X)
-            return torch.softmax(out, -1).cpu().numpy()
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        h = self.encoder(x)
+        return self.classifier(h)
 
     # --------------------------------------------------------------
-    def predict(self, X):
-        return self.predict_proba(X).argmax(1)
+    def loss(
+        self, x: torch.Tensor, y: torch.Tensor, _t_obs: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """Combined loss for the two-stage VIME algorithm."""
+
+        if y.dim() > 1:
+            y = y.argmax(1)
+        y = y.to(torch.long)
+
+        # ---- stage 1 : self-supervised pre-training -----------------
+        m, xt = mask_corrupt(x, self.p_m)
+        h_pt = self.encoder(xt)
+        m_hat, x_hat = self.decoder(h_pt)
+        loss_pre = F.binary_cross_entropy(m_hat, m) + self.alpha * F.mse_loss(x_hat, x)
+
+        # ---- stage 2 : semi-supervised classification ----------------
+        logits = self.forward(x)
+        labelled = y >= 0
+        loss_sup = (
+            F.cross_entropy(logits[labelled], y[labelled])
+            if labelled.any()
+            else torch.tensor(0.0, device=x.device)
+        )
+
+        if (~labelled).any():
+            x_u = x[~labelled]
+            x_u_k = torch.stack(
+                [mask_corrupt(x_u, p_m=self.p_m)[1] for _ in range(self.K)]
+            )
+            logits_u = self.forward(x_u_k.view(-1, x_u.size(1))).view(
+                self.K, x_u.size(0), -1
+            )
+            loss_unsup = F.mse_loss(
+                logits_u.mean(0, keepdim=True).expand_as(logits_u), logits_u
+            )
+        else:
+            loss_unsup = torch.tensor(0.0, device=x.device)
+
+        # total --------------------------------------------------------
+        return loss_pre + loss_sup + self.beta * loss_unsup
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_proba(self, X: torch.Tensor | list) -> torch.Tensor:
+        X_t = torch.as_tensor(
+            X, dtype=torch.float32, device=next(self.parameters()).device
+        )
+        logits = self.forward(X_t)
+        return logits.softmax(dim=-1).cpu()
+
+    # --------------------------------------------------------------
+    def predict(self, X: torch.Tensor | list) -> torch.Tensor:
+        return self.predict_proba(X).argmax(dim=1)
+
+
+__all__ = ["VIME"]


### PR DESCRIPTION
## Summary
- merge pretraining into the `loss` function so VIME trains in one stage
- update the documentation snippet for the new API
- simplify VIME test to rely solely on `Trainer`

## Testing
- `pre-commit run --files xtylearner/models/vime.py tests/test_vime_model.py docs/baselines/vime.md xtylearner/models/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c75461d588324b4fe161efdaaa716