### PR TITLE
Implement forward pass for CycleDual

### DIFF
--- a/xtylearner/models/cycle_dual.py
+++ b/xtylearner/models/cycle_dual.py
@@ -57,6 +57,13 @@ class CycleDual(nn.Module):
         )
 
     # ------------------------------------------------------------------
+    def forward(self, X: torch.Tensor, T: torch.Tensor) -> torch.Tensor:
+        """Predict outcome ``Y`` from covariates ``X`` and treatment ``T``."""
+
+        T_1h = one_hot(T.to(torch.long), self.k).float()
+        return self.G_Y(torch.cat([X, T_1h], dim=-1))
+
+    # ------------------------------------------------------------------
     def loss(self, X, Y, T_obs, λ_sup=1.0, λ_cyc=1.0, λ_ent=0.1):
         """
         X : (B, d_x)     Y : (B, d_y)


### PR DESCRIPTION
## Summary
- add a `forward` method in `CycleDual` for outcome prediction

## Testing
- `pre-commit run --files xtylearner/models/cycle_dual.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca3946de883248d114997facaa023