### PR TITLE
Add forward methods for supervised models

### DIFF
--- a/xtylearner/models/gflownet_treatment.py
+++ b/xtylearner/models/gflownet_treatment.py
@@ -119,10 +119,11 @@ class GFlowNetTreatment(nn.Module):
         return tb_loss + outcome_loss
 
     # --------------------------------------------------------------
-    def forward(self, x: torch.Tensor, t: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return outcome parameters ``p(y|x,t)``."""
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        """Return the mean of ``p(y|x,t)`` from the outcome model."""
 
-        return self.outcome(x, t)
+        mu, _ = self.outcome(x, t)
+        return mu
 
     # --------------------------------------------------------------
     @torch.no_grad()


### PR DESCRIPTION
## Summary
- implement gradient-based MAP forward for `MixtureOfFlows`
- add energy-minimisation forward method to `EnergyDiffusionImputer`
- return mean prediction in `GFlowNetTreatment.forward`

## Testing
- `ruff check xtylearner/models/flow_ssc.py xtylearner/models/energy_diffusion_imputer.py xtylearner/models/gflownet_treatment.py`
- `black --check xtylearner/models/flow_ssc.py xtylearner/models/energy_diffusion_imputer.py xtylearner/models/gflownet_treatment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce7e29aac83249dafba8bf4c249f4