### PR TITLE
Add extra unit tests

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import torch
+import pytest
 
 from xtylearner.data import (
     load_toy_dataset,
@@ -126,3 +127,19 @@ def test_load_tabular_with_string_treatments():
     assert Y.shape == (4, 1)
     assert T.dtype == torch.int64
     assert getattr(ds, "treatment_mapping") == {"a": 0, "b": 1}
+
+# Additional tests
+
+def test_load_tabular_invalid_type():
+    with pytest.raises(TypeError):
+        load_tabular_dataset(123)
+
+def test_load_tabular_missing_columns():
+    df = pd.DataFrame({"x1": [0.0, 1.0], "x2": [0.0, 1.0]})
+    with pytest.raises(ValueError):
+        load_tabular_dataset(df)
+
+def test_load_tabular_bad_numpy_shape():
+    arr = np.zeros((2, 2), dtype=np.float32)
+    with pytest.raises(ValueError):
+        load_tabular_dataset(arr, outcome_col=1)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,39 @@
+import torch
+import yaml
+import pytest
+from torch.utils.data import DataLoader, TensorDataset
+
+from xtylearner.configs import load as load_config
+from xtylearner.models.lt_flow_diff import _sigma
+from xtylearner.training import ArrayTrainer
+
+
+class DummyModel:
+    def fit(self, *args, **kwargs):
+        pass
+
+
+def test_config_load(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("a: 1\nb:\n  c: 2\n")
+    cfg = load_config(cfg_path)
+    assert cfg == {"a": 1, "b": {"c": 2}}
+
+
+def test_sigma_schedule_bounds():
+    smin, smax = 0.1, 1.0
+    assert _sigma(torch.tensor(0.0), smin, smax).item() == pytest.approx(smin)
+    assert _sigma(torch.tensor(1.0), smin, smax).item() == pytest.approx(smax)
+
+
+def test_collect_arrays_shapes():
+    X = torch.randn(4, 2)
+    Y = torch.randn(4, 1)
+    T = torch.tensor([0, 1, 0, 1])
+    loader = DataLoader(TensorDataset(X, Y, T), batch_size=2)
+    opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
+    trainer = ArrayTrainer(DummyModel(), opt, loader)
+    X_arr, Y_arr, T_arr = trainer._collect_arrays(loader)
+    assert X_arr.shape == (4, 2)
+    assert Y_arr.shape == (4,)
+    assert T_arr.shape == (4,)


### PR DESCRIPTION
## Summary
- add tests for error handling in `load_tabular_dataset`
- cover config loading, sigma schedule, and array collection utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9d82df7c8324a2129073efd40dec