### PR TITLE
Refactor VAT model architecture

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -50,7 +50,7 @@ from xtylearner.models import (
             MeanTeacher,
             {"base_net_fn": lambda n: nn.Linear(3, n), "num_classes": 2},
         ),
-        ("vat", VAT_Model, {}),
+        ("vat", VAT_Model, {"d_x": 2, "d_y": 1, "k": 2}),
         ("fixmatch", FixMatch, {}),
     ],
 )

--- a/tests/test_vat_model.py
+++ b/tests/test_vat_model.py
@@ -3,11 +3,17 @@ import torch
 from xtylearner.models import VAT_Model
 
 
-def test_vat_supports_multitarget():
-    X_lab = torch.randn(4, 3)
-    y_lab = torch.randint(0, 2, (4, 2))
-    X_unlab = torch.randn(6, 3)
-    model = VAT_Model()
-    model.fit(X_lab, y_lab, X_unlab, epochs=1, bs=2)
-    out = model.predict_proba(torch.randn(3, 3))
-    assert out.shape == (3, 2)
+def test_vat_basic_shapes():
+    model = VAT_Model(d_x=3, d_y=1, k=2)
+    x = torch.randn(5, 3)
+    y = torch.randn(5, 1)
+    t = torch.randint(0, 2, (5,))
+
+    out = model(x, t)
+    assert out.shape == (5, 1)
+
+    loss = model.loss(x, y, t)
+    assert isinstance(loss, torch.Tensor)
+
+    probs = model.predict_treatment_proba(x, y)
+    assert probs.shape == (5, 2)


### PR DESCRIPTION
## Summary
- refactor VAT model into nn.Module and expose outcome & treatment networks
- add loss, forward, predict_treatment_proba methods
- update tests for new API and registry parameters

## Testing
- `pre-commit run --files xtylearner/models/vat.py tests/test_registry.py tests/test_vat_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da3343cd48324a1eb7f0cd538acff