### PR TITLE
Handle VAT evaluation w/out gradients

### DIFF
--- a/xtylearner/models/vat.py
+++ b/xtylearner/models/vat.py
@@ -108,13 +108,18 @@ class VAT_Model(nn.Module):
                 logits_t[mask], t_use[mask]
             )
 
-        vat_inp = torch.cat([x, y], dim=-1)
-        L_vat = vat_loss(
-            self.classifier, vat_inp, xi=self.xi, eps=self.eps, n_power=self.n_power
-        )
-        lam = ramp_up_sigmoid(self.step, self.ramp, self.lambda_max)
-        self.step += 1
-        loss = loss + lam * L_vat
+        if torch.is_grad_enabled():
+            vat_inp = torch.cat([x, y], dim=-1)
+            L_vat = vat_loss(
+                self.classifier,
+                vat_inp,
+                xi=self.xi,
+                eps=self.eps,
+                n_power=self.n_power,
+            )
+            lam = ramp_up_sigmoid(self.step, self.ramp, self.lambda_max)
+            self.step += 1
+            loss = loss + lam * L_vat
         return loss
 
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid VAT loss when gradients are disabled

## Testing
- `pre-commit run --files xtylearner/models/vat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dab3b96188324b0a723937741fb0a