### PR TITLE
Add GANITE model and adversarial trainer

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -24,6 +24,7 @@ from xtylearner.models import (
     FixMatch,
     SSDMLModel,
     SS_CEVAE,
+    GANITE,
 )
 
 
@@ -46,6 +47,7 @@ from xtylearner.models import (
         ("masked_tabular_transformer", MaskedTabularTransformer, {"d_x": 2}),
         ("prob_circuit", ProbCircuitModel, {}),
         ("lp_knn", LP_KNN, {}),
+        ("ganite", GANITE, {"d_x": 2, "d_y": 1}),
         (
             "mean_teacher",
             MeanTeacher,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -7,6 +7,7 @@ from xtylearner.training import Trainer
 from xtylearner.models import M2VAE, SS_CEVAE, JSBF, DiffusionCEVAE
 from xtylearner.models import BridgeDiff, LTFlowDiff
 from xtylearner.models import EnergyDiffusionImputer, JointEBM, GFlowNetTreatment
+from xtylearner.models import GANITE
 from xtylearner.models import ProbCircuitModel, LP_KNN
 
 
@@ -44,7 +45,9 @@ def test_multitask_model_runs():
 
 
 def test_multitask_handles_missing_labels():
-    dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=42, label_ratio=0.5)
+    dataset = load_mixed_synthetic_dataset(
+        n_samples=20, d_x=2, seed=42, label_ratio=0.5
+    )
     loader = DataLoader(dataset, batch_size=5)
     model = MultiTask(d_x=2, d_y=1, k=2)
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
@@ -178,6 +181,20 @@ def test_gflownet_treatment_trainer_runs():
     model = GFlowNetTreatment(d_x=2, d_y=1)
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_ganite_trainer_runs():
+    dataset = load_mixed_synthetic_dataset(
+        n_samples=20, d_x=2, seed=17, label_ratio=0.5
+    )
+    loader = DataLoader(dataset, batch_size=5)
+    model = GANITE(d_x=2, d_y=1)
+    opt_g = torch.optim.Adam(model.parameters(), lr=0.001)
+    opt_d = torch.optim.Adam(model.parameters(), lr=0.001)
+    trainer = Trainer(model, (opt_g, opt_d), loader)
     trainer.fit(1)
     loss = trainer.evaluate(loader)
     assert isinstance(loss, float)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -19,6 +19,7 @@ from .vime import VIME
 from .vat import VAT_Model
 from .fixmatch import FixMatch
 from .ss_dml import SSDMLModel
+from .ganite import GANITE
 from .registry import get_model, get_model_names, get_model_args
 
 __all__ = [
@@ -43,6 +44,7 @@ __all__ = [
     "VAT_Model",
     "FixMatch",
     "SSDMLModel",
+    "GANITE",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/ganite.py
+++ b/xtylearner/models/ganite.py
@@ -1,0 +1,131 @@
+"""Adversarial GANITE model."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Callable
+
+from .layers import make_mlp
+from .registry import register_model
+from ..training.metrics import mse_loss, cross_entropy_loss
+
+
+@register_model("ganite")
+class GANITE(nn.Module):
+    """Binary-treatment GANITE (Yoon et al., 2018)."""
+
+    k = 2
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int = 1,
+        *,
+        hidden_dims: tuple[int, ...] | list[int] = (200, 200),
+        activation: type[nn.Module] = nn.ReLU,
+        dropout: float | None = None,
+        norm_layer: Callable[[int], nn.Module] | None = None,
+    ) -> None:
+        super().__init__()
+        self.G_cf = make_mlp(
+            [d_x + d_y + self.k, *hidden_dims, d_y],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.G_ite = make_mlp(
+            [d_x + self.k, *hidden_dims, d_y],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.D_y = make_mlp(
+            [d_x + d_y + self.k, *hidden_dims, 1],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+        self.C_t = make_mlp(
+            [d_x + d_y, *hidden_dims, self.k],
+            activation=activation,
+            dropout=dropout,
+            norm_layer=norm_layer,
+        )
+
+    # --------------------------------------------------------------
+    def _impute_treatment(
+        self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return one-hot treatment, counterfactual one-hot and logits."""
+        logits = self.C_t(torch.cat([x, y], dim=-1))
+        t_pred = logits.argmax(-1)
+        mask = t_obs >= 0
+        t_use = torch.where(mask, t_obs, t_pred)
+        t1h = F.one_hot(t_use.to(torch.long), self.k).float()
+        t_cf = 1 - t_use
+        t1h_cf = F.one_hot(t_cf.to(torch.long), self.k).float()
+        return t1h, t1h_cf, logits
+
+    # --------------------------------------------------------------
+    def loss_G(
+        self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor
+    ) -> dict[str, torch.Tensor]:
+        t1h, t1h_cf, logits = self._impute_treatment(x, y, t_obs)
+
+        y_cf_hat = self.G_cf(torch.cat([x, y, t1h], dim=-1))
+        d_out = self.D_y(torch.cat([x, y_cf_hat, t1h_cf], dim=-1))
+        loss_adv = F.binary_cross_entropy_with_logits(d_out, torch.ones_like(d_out))
+
+        y_f_hat = self.G_ite(torch.cat([x, t1h], dim=-1))
+        mask = t_obs >= 0
+        loss_f = (
+            mse_loss(y_f_hat[mask], y[mask])
+            if mask.any()
+            else torch.tensor(0.0, device=x.device)
+        )
+        loss_cls = (
+            cross_entropy_loss(logits[mask], t_obs[mask])
+            if mask.any()
+            else torch.tensor(0.0, device=x.device)
+        )
+        loss_g = loss_adv + loss_f + loss_cls
+        return {"loss_G": loss_g}
+
+    # --------------------------------------------------------------
+    def loss_D(
+        self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor
+    ) -> dict[str, torch.Tensor]:
+        t1h, t1h_cf, _ = self._impute_treatment(x, y, t_obs)
+        mask = t_obs >= 0
+        if not mask.any():
+            return {"loss_D": torch.tensor(0.0, device=x.device)}
+
+        y_cf_hat = self.G_cf(torch.cat([x, y, t1h], dim=-1)).detach()
+        real = self.D_y(torch.cat([x[mask], y[mask], t1h[mask]], dim=-1))
+        fake = self.D_y(torch.cat([x[mask], y_cf_hat[mask], t1h_cf[mask]], dim=-1))
+        loss_real = F.binary_cross_entropy_with_logits(real, torch.ones_like(real))
+        loss_fake = F.binary_cross_entropy_with_logits(fake, torch.zeros_like(fake))
+        return {"loss_D": loss_real + loss_fake}
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_outcome(
+        self, x: torch.Tensor | np.ndarray, t: torch.Tensor | np.ndarray
+    ) -> torch.Tensor:
+        if not torch.is_tensor(x):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        if not torch.is_tensor(t):
+            t = torch.as_tensor(t, dtype=torch.long)
+        t1h = F.one_hot(t.to(torch.long), self.k).float()
+        return self.G_ite(torch.cat([x, t1h], dim=-1))
+
+    @torch.no_grad()
+    def predict_treatment_proba(self, z: torch.Tensor) -> torch.Tensor:
+        logits = self.C_t(z)
+        return logits.softmax(-1)
+
+
+__all__ = ["GANITE"]

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -4,6 +4,7 @@ from .base_trainer import BaseTrainer
 from .logger import TrainerLogger, ConsoleLogger
 from .trainer import Trainer
 from .supervised import SupervisedTrainer
+from .adversarial import AdversarialTrainer
 from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
 from .em import ArrayTrainer, EMTrainer
@@ -20,6 +21,7 @@ __all__ = [
     "SupervisedTrainer",
     "GenerativeTrainer",
     "DiffusionTrainer",
+    "AdversarialTrainer",
     "ArrayTrainer",
     "EMTrainer",
     "Trainer",

--- a/xtylearner/training/adversarial.py
+++ b/xtylearner/training/adversarial.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import torch
+
+from .base_trainer import BaseTrainer
+from .logger import TrainerLogger
+
+
+class AdversarialTrainer(BaseTrainer):
+    """Trainer for models with ``loss_G`` and ``loss_D`` methods."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optim_G: torch.optim.Optimizer,
+        optim_D: torch.optim.Optimizer,
+        train_loader: Iterable,
+        val_loader: Optional[Iterable] = None,
+        device: str = "cpu",
+        logger: Optional[TrainerLogger] = None,
+        scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
+        grad_clip_norm: float | None = None,
+    ) -> None:
+        super().__init__(
+            model,
+            optim_G,
+            train_loader,
+            val_loader,
+            device,
+            logger,
+            scheduler,
+            grad_clip_norm,
+        )
+        self.optim_G = optim_G
+        self.optim_D = optim_D
+
+    # --------------------------------------------------------------
+    def step(self, batch: Iterable[torch.Tensor]) -> dict[str, torch.Tensor]:
+        x, y, t = self._extract_batch(batch)
+
+        if not torch.is_grad_enabled():
+            loss = self.model.loss_G(x, y, t)
+            loss.update(self.model.loss_D(x, y, t))
+            return loss
+
+        self.optim_G.zero_grad()
+        loss_dict = self.model.loss_G(x, y, t)
+        loss_dict["loss_G"].backward()
+        self._clip_grads()
+        self.optim_G.step()
+
+        self.optim_D.zero_grad()
+        loss_dict.update(self.model.loss_D(x, y, t))
+        loss_dict["loss_D"].backward()
+        self._clip_grads()
+        self.optim_D.step()
+        return loss_dict
+
+    # --------------------------------------------------------------
+    def fit(self, num_epochs: int) -> None:
+        for epoch in range(num_epochs):
+            self.model.train()
+            num_batches = len(self.train_loader)
+            if self.logger:
+                self.logger.start_epoch(epoch + 1, num_batches)
+            for batch_idx, batch in enumerate(self.train_loader):
+                X, Y, T_obs = self._extract_batch(batch)
+                losses = self.step(batch)
+                if self.logger:
+                    metrics = dict(self._metrics_from_loss(losses))
+                    metrics.update(self._treatment_metrics(X, Y, T_obs))
+                    metrics.update(self._outcome_metrics(X, Y, T_obs))
+                    self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
+            if self.scheduler is not None:
+                self.scheduler.step()
+            if self.logger and self.val_loader is not None:
+                val_metrics = self._eval_metrics(self.val_loader)
+                self.logger.log_validation(epoch + 1, val_metrics)
+            if self.logger:
+                self.logger.end_epoch(epoch + 1)
+
+    # --------------------------------------------------------------
+    def evaluate(self, data_loader: Iterable) -> float:
+        metrics = self._eval_metrics(data_loader)
+        return metrics.get("loss_G", next(iter(metrics.values()), 0.0))
+
+    def predict(self, *inputs: torch.Tensor):
+        self.model.eval()
+        with torch.no_grad():
+            inputs = [i.to(self.device) for i in inputs]
+            if hasattr(self.model, "predict"):
+                return self.model.predict(*inputs)
+            return self.model(*inputs)
+
+
+__all__ = ["AdversarialTrainer"]


### PR DESCRIPTION
## Summary
- implement `GANITE` model
- add `AdversarialTrainer`
- route adversarial models in `Trainer`
- register the new model and expose new trainer
- test coverage for model registry and trainer

## Testing
- `ruff check xtylearner/models/ganite.py xtylearner/training/adversarial.py xtylearner/training/trainer.py xtylearner/training/__init__.py xtylearner/models/__init__.py tests/test_registry.py tests/test_trainer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc17d4ef48324a798fdd528cc4712