### PR TITLE
Fix pip install race

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = ["xtylearner*"]
 xtylearner = ["configs/*.yaml"]
 
 [tool.pytest.ini_options]
-addopts = "-vv"
+addopts = "-vv --dist=loadgroup"
 testpaths = ["tests"]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- ensure wheel-building tests run on same worker by using `--dist=loadgroup`

## Testing
- `pytest -k test_package_install -vv`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_686dcc7e5d848324b3da01c43f7dab1b