### PR TITLE
Fix DragonNet targeted regularization

### DIFF
--- a/xtylearner/models/dragon_net.py
+++ b/xtylearner/models/dragon_net.py
@@ -63,8 +63,9 @@ class DragonNet(nn.Module):
         tar_reg = torch.tensor(0.0, device=x.device)
         if labelled.any():
             t_onehot = F.one_hot(t_lab, self.k).float()
-            mu_lab = mu_hat[labelled].squeeze(-1)
-            tau_dr = ((t_onehot / pi_hat[labelled]).mul(y_lab.unsqueeze(1) - mu_lab)).mean(0)
+            mu_lab = mu_hat[labelled]
+            weight = (t_onehot / pi_hat[labelled]).unsqueeze(-1)
+            tau_dr = (weight * (y_lab.unsqueeze(1) - mu_lab)).mean(0)
             tar_reg = tau_dr.pow(2).sum()
 
         l1, l2, l3, l4 = self.lmbda


### PR DESCRIPTION
## Summary
- fix broadcasting in DragonNet so multi-output outcomes work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dcee3e244832499f7ddc997d3cb1d