### PR TITLE
Expose embed_dim parameter for BridgeDiff

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -43,7 +43,7 @@ from xtylearner.models import (
         ("dragon_net", DragonNet, {"d_x": 2, "d_y": 1, "k": 2}),
         ("m2_vae", M2VAE, {"d_x": 2, "d_y": 1, "k": 2}),
         ("ss_cevae", SS_CEVAE, {"d_x": 2, "d_y": 1, "k": 2}),
-        ("bridge_diff", BridgeDiff, {"d_x": 2, "d_y": 1}),
+        ("bridge_diff", BridgeDiff, {"d_x": 2, "d_y": 1, "embed_dim": 16}),
         ("lt_flow_diff", LTFlowDiff, {"d_x": 2, "d_y": 1}),
         ("jsbf", JSBF, {"d_x": 2, "d_y": 1}),
         ("masked_tabular_transformer", MaskedTabularTransformer, {"d_x": 2}),

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -164,7 +164,7 @@ def test_diffusion_cevae_trainer_runs():
 def test_bridge_diff_trainer_runs():
     dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=9, label_ratio=0.5)
     loader = DataLoader(dataset, batch_size=5)
-    model = BridgeDiff(d_x=2, d_y=1)
+    model = BridgeDiff(d_x=2, d_y=1, embed_dim=16)
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)

--- a/xtylearner/models/bridge_diff.py
+++ b/xtylearner/models/bridge_diff.py
@@ -68,6 +68,7 @@ class BridgeDiff(nn.Module):
         sigma_min: float = 0.002,
         sigma_max: float = 1.0,
         k: int = 2,
+        embed_dim: int = 64,
     ) -> None:
         super().__init__()
         self.d_y = d_y
@@ -75,7 +76,7 @@ class BridgeDiff(nn.Module):
         self.timesteps = timesteps
         self.sigma_min = sigma_min
         self.sigma_max = sigma_max
-        self.score_net = ScoreBridge(d_x, d_y, k, hidden)
+        self.score_net = ScoreBridge(d_x, d_y, k, hidden, embed_dim)
         self.classifier = Classifier(d_x, d_y, k)
 
     # ----- utilities -----


### PR DESCRIPTION
## Summary
- allow `BridgeDiff` to receive an `embed_dim` argument
- adjust tests to use the new constructor argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfd560438832483af7c6a2b2219ba