### PR TITLE
Implement CEVAE-M generative model

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The model registry exposes a variety of architectures grouped below by type.
   combining an invertible network with a classifier.
 - ``M2VAE`` – a generative model based on the M2 variational autoencoder.
 - ``SS_CEVAE`` – a semi-supervised extension of the CEVAE framework.
+- ``CEVAE_M`` – CEVAE with latent treatment for partially-observed labels.
 - ``JointEBM`` – an energy-based model of the joint distribution ``(X, T, Y)``
   optimised with a contrastive objective.
 - ``ProbCircuitModel`` – a probabilistic circuit baseline leveraging SPFlow

--- a/docs/baselines/cevae_m.md
+++ b/docs/baselines/cevae_m.md
@@ -1,0 +1,27 @@
+CEVAE-M extends the original CEVAE to settings where the treatment label is missing for many samples. It keeps the CEVAE generative structure but models missing treatments as latent variables.
+
+### Objective
+
+For each mini-batch the model samples a soft treatment assignment `t` from `q(t|x,y)` using the Gumbel-Softmax trick. The latent confounder `z` is drawn from `q(z|x,y,t)`. The evidence lower bound is
+
+\[
+\mathbb E_{q(t|x,y)}\Big[\mathbb E_{q(z|x,y,t)}[\log p(x|z)+\log p(t|z)+\log p(y|x,t,z)]-\mathrm{KL}(q(z|x,y,t)\,||\,p(z))\Big]
+\]
+plus a cross-entropy term on observed treatments.
+
+### Tips
+
+- Temperature `tau` controls the sharpness of the Gumbel-Softmax samples.
+- A larger latent dimension `d_z` often helps on IHDP style data.
+- Train for roughly 400 epochs with Adam at learning rate 1e-3.
+
+### Citation
+
+```
+@inproceedings{louizos2017cevae,
+  title     = {Causal Effect Inference with Deep Latent-Variable Models},
+  author    = {Louizos, Christos and others},
+  booktitle = {NeurIPS},
+  year      = {2017}
+}
+```

--- a/examples/cevae_m_ihdp.py
+++ b/examples/cevae_m_ihdp.py
@@ -1,0 +1,22 @@
+"""Train CEVAE-M on the IHDP semi-synthetic dataset."""
+
+import torch
+from torch.utils.data import DataLoader
+
+from xtylearner.data import load_ihdp
+from xtylearner.models import CEVAE_M
+from xtylearner.training import Trainer, ConsoleLogger
+
+
+def main() -> None:
+    ds = load_ihdp()
+    loader = DataLoader(ds, batch_size=256, shuffle=True)
+    model = CEVAE_M(d_x=ds.tensors[0].size(1), d_y=1, k=2, d_z=32, hidden=128, tau=0.66)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    logger = ConsoleLogger()
+    trainer = Trainer(model, opt, loader, logger=logger)
+    trainer.fit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/test_cevae_m.py
+++ b/tests/models/test_cevae_m.py
@@ -1,0 +1,55 @@
+import torch
+from torch.utils.data import DataLoader
+
+from xtylearner.data import load_synthetic_dataset
+from xtylearner.models import CEVAE_M
+from xtylearner.training import Trainer
+
+
+def test_shapes_and_loss_scalar():
+    ds = load_synthetic_dataset(n_samples=10, d_x=2, seed=0)
+    X, Y, T = ds.tensors
+    model = CEVAE_M(d_x=2, d_y=1, k=2)
+    loss = model.loss(X, Y, T)
+    assert loss.dim() == 0
+    probs = model.predict_treatment_proba(X, Y)
+    assert probs.shape == (10, 2)
+    out = model.predict_outcome(X, torch.zeros(10, dtype=torch.long))
+    assert out.shape == (10, 1)
+
+
+def test_backward_runs():
+    ds = load_synthetic_dataset(n_samples=8, d_x=2, seed=1)
+    X, Y, T = ds.tensors
+    model = CEVAE_M(d_x=2, d_y=1, k=2)
+    loss = model.loss(X, Y, T)
+    loss.backward()
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+def test_trainer_integration():
+    ds = load_synthetic_dataset(n_samples=20, d_x=2, seed=2)
+    loader = DataLoader(ds, batch_size=5)
+    model = CEVAE_M(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+
+
+def test_pehe_sanity():
+    ds = load_synthetic_dataset(n_samples=30, d_x=2, seed=3)
+    X, Y, T = ds.tensors
+    model = CEVAE_M(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    loader = DataLoader(ds, batch_size=10)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+
+    with torch.no_grad():
+        y0 = model.predict_outcome(X, torch.zeros(len(X), dtype=torch.long))
+        y1 = model.predict_outcome(X, torch.ones(len(X), dtype=torch.long))
+    ite_pred = (y1 - y0).squeeze(1)
+    true_ite = torch.full_like(ite_pred, 2.0)
+    pehe = torch.sqrt(((ite_pred - true_ite) ** 2).mean())
+    assert torch.isfinite(pehe)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -25,6 +25,7 @@ from xtylearner.models import (
     FixMatch,
     SSDMLModel,
     SS_CEVAE,
+    CEVAE_M,
     GANITE,
 )
 
@@ -43,6 +44,7 @@ from xtylearner.models import (
         ("dragon_net", DragonNet, {"d_x": 2, "d_y": 1, "k": 2}),
         ("m2_vae", M2VAE, {"d_x": 2, "d_y": 1, "k": 2}),
         ("ss_cevae", SS_CEVAE, {"d_x": 2, "d_y": 1, "k": 2}),
+        ("cevae_m", CEVAE_M, {"d_x": 2, "d_y": 1, "k": 2}),
         ("bridge_diff", BridgeDiff, {"d_x": 2, "d_y": 1, "embed_dim": 16}),
         ("lt_flow_diff", LTFlowDiff, {"d_x": 2, "d_y": 1}),
         ("jsbf", JSBF, {"d_x": 2, "d_y": 1}),

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -4,6 +4,7 @@ from .cycle_dual import CycleDual
 from .flow_ssc import MixtureOfFlows
 from .multitask_selftrain import MultiTask
 from .generative import M2VAE, SS_CEVAE, DiffusionCEVAE
+from .cevae_m_model import CEVAE_M
 from .energy_diffusion_imputer import EnergyDiffusionImputer
 from .joint_ebm import JointEBM
 from .jsbf_model import JSBF
@@ -30,6 +31,7 @@ __all__ = [
     "M2VAE",
     "SS_CEVAE",
     "DiffusionCEVAE",
+    "CEVAE_M",
     "JSBF",
     "BridgeDiff",
     "LTFlowDiff",

--- a/xtylearner/models/cevae_m_model.py
+++ b/xtylearner/models/cevae_m_model.py
@@ -1,0 +1,116 @@
+"""CEVAE with latent treatment for partially-observed T."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Normal
+
+from .registry import register_model
+
+
+class MLP(nn.Sequential):
+    """Simple two-layer MLP used for encoders/decoders."""
+
+    def __init__(self, in_dim: int, hidden: int, out_dim: int) -> None:
+        super().__init__(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, out_dim),
+        )
+
+
+class CondDiagGaussian(nn.Module):
+    """Conditional diagonal Gaussian ``q(z|h)`` with reparameterisation."""
+
+    def __init__(self, in_dim: int, hidden: int, out_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU())
+        self.mu_layer = nn.Linear(hidden, out_dim)
+        self.logv_layer = nn.Linear(hidden, out_dim)
+
+    def forward(self, h: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        h = self.net(h)
+        mu = self.mu_layer(h)
+        logv = self.logv_layer(h).clamp(-8, 8)
+        std = (0.5 * logv).exp()
+        z = mu + std * torch.randn_like(std)
+        return z, mu, logv
+
+    def mu(self, h: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        h = self.net(h)
+        return self.mu_layer(h)
+
+
+def sample_or_clamp(logits: torch.Tensor, t_obs: torch.Tensor, tau: float) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sample from Gumbel-Softmax or clamp to observed one-hot."""
+    b, k = logits.size()
+    mask = t_obs >= 0
+    if mask.any():
+        t_onehot = F.one_hot(t_obs.clamp_min(0), k).float()
+    else:
+        t_onehot = torch.zeros(b, k, device=logits.device)
+    t_soft = F.gumbel_softmax(logits, tau=tau, hard=False)
+    t_soft = torch.where(mask.unsqueeze(-1), t_onehot, t_soft)
+    log_q_t = F.log_softmax(logits, dim=1)
+    log_q_t = (t_soft * log_q_t).sum(1)
+    return t_soft, log_q_t
+
+
+@register_model("cevae_m")
+class CEVAE_M(nn.Module):
+    """CEVAE with latent treatment for partially-observed T."""
+
+    k: int  # number of treatment categories
+
+    def __init__(self, d_x: int, d_y: int, k: int = 2, d_z: int = 16, hidden: int = 64, tau: float = 0.5) -> None:
+        super().__init__()
+        self.k, self.tau = k, tau
+        # encoders
+        self.enc_logits_t = MLP(d_x + d_y, hidden, k)
+        self.enc_z = CondDiagGaussian(d_x + d_y + k, hidden, d_z)
+        # decoders
+        self.dec_x = MLP(d_z, hidden, d_x)
+        self.dec_t = MLP(d_z, hidden, k)
+        self.dec_y = MLP(d_x + k + d_z, hidden, d_y)
+
+    # --------------------------------------------------------------
+    def loss(self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor) -> torch.Tensor:
+        logits_t = self.enc_logits_t(torch.cat([x, y], 1))
+        t_soft, log_q_t = sample_or_clamp(logits_t, t_obs, self.tau)
+
+        z, mu, logv = self.enc_z(torch.cat([x, y, t_soft], 1))
+
+        log_px = Normal(self.dec_x(z), 1.0).log_prob(x).sum(1)
+        log_pt = (t_soft * F.log_softmax(self.dec_t(z), 1)).sum(1)
+        log_py = Normal(self.dec_y(torch.cat([x, t_soft, z], 1)), 1.0).log_prob(y).sum(1)
+        kl_z = -0.5 * (1 + logv - mu.pow(2) - logv.exp()).sum(1)
+
+        elbo = (log_px + log_pt + log_py - kl_z - log_q_t).mean()
+        if (t_obs >= 0).any():
+            ce_sup = F.cross_entropy(logits_t[t_obs >= 0], t_obs[t_obs >= 0])
+        else:
+            ce_sup = torch.tensor(0.0, device=x.device)
+        return -(elbo) + ce_sup
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return F.softmax(self.enc_logits_t(torch.cat([x, y], 1)), 1)
+
+    @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        t_onehot = F.one_hot(t, self.k).float() if t.dim() == 1 else t
+        z = self.enc_z.mu(torch.cat([x, torch.zeros_like(x[:, :1]), t_onehot], 1))
+        return self.dec_y(torch.cat([x, t_onehot, z], 1))
+
+    @torch.no_grad()
+    def sample_counterfactual(self, x: torch.Tensor, y: torch.Tensor, t_prime: torch.Tensor) -> torch.Tensor:
+        t_hat = self.predict_treatment_proba(x, y).argmax(1)
+        z = self.enc_z.mu(torch.cat([x, y, F.one_hot(t_hat, self.k).float()], 1))
+        y_cf = self.dec_y(torch.cat([x, F.one_hot(t_prime, self.k).float(), z], 1))
+        return y_cf
+
+
+__all__ = ["CEVAE_M"]

--- a/xtylearner/models/generative.py
+++ b/xtylearner/models/generative.py
@@ -2,6 +2,7 @@
 
 from .m2vae_model import M2VAE
 from .ss_cevae_model import SS_CEVAE
+from .cevae_m_model import CEVAE_M
 from .jsbf_model import JSBF
 from .diffusion_cevae import DiffusionCEVAE
 from .bridge_diff import BridgeDiff
@@ -11,6 +12,7 @@ from .energy_diffusion_imputer import EnergyDiffusionImputer
 __all__ = [
     "M2VAE",
     "SS_CEVAE",
+    "CEVAE_M",
     "DiffusionCEVAE",
     "JSBF",
     "BridgeDiff",


### PR DESCRIPTION
## Summary
- add `CEVAE_M` generative model for missing treatments
- import in registry and update generative wrappers
- document CEVAE_M usage and add example script
- extend test suite with CEVAE_M coverage

## Testing
- `pytest -q` *(fails: unrecognized arguments --dist=loadgroup)*

------
https://chatgpt.com/codex/tasks/task_e_686e04cbf7008324a0615ebb58f10697