### PR TITLE
Add Deconfounder CFM model

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ The model registry exposes a variety of architectures grouped below by type.
 - ``EMModel`` – a lightweight EM algorithm implementation for linear models.
 - ``GANITE`` – a GAN-based approach for individual treatment effect estimation.
 
+#### Causal Factor Models
+
+- ``deconfounder_cfm`` – two-stage factor model that learns a substitute
+  confounder from multiple correlated treatments.
+
 #### Diffusion
 
 - ``JSBF`` – a score-based diffusion model of the full joint

--- a/docs/baselines/deconfounder.md
+++ b/docs/baselines/deconfounder.md
@@ -1,0 +1,16 @@
+The **deconfounder** or Causal-Factor Model fits a latent variable model to the set of treatments only. 
+After learning a substitute confounder ``z`` it trains a separate outcome network conditioned on ``[x, t, z]``.
+
+### Assumptions
+
+- Hidden confounders affect at least two causes (no single‑cause confounders).
+- The treatment factor model is well specified. A posterior predictive check using HSIC between generated treatments and ``z`` should be near zero.
+
+### Key hyper-parameters
+
+- ``d_z`` – dimensionality of the latent confounder.
+- ``hidden`` – width of hidden layers in both networks.
+- ``pretrain_epochs`` – number of epochs to train the treatment VAE before updating the outcome head.
+- ``ppc_freq`` – frequency of HSIC diagnostics during training.
+
+The deconfounder is useful when multiple causes share latent confounders and some treatment values may be missing.

--- a/examples/deconfounder_twin_pehe.py
+++ b/examples/deconfounder_twin_pehe.py
@@ -1,0 +1,32 @@
+"""Train DeconfounderCFM on the Twins dataset and report PEHE."""
+
+import torch
+from torch.utils.data import DataLoader
+
+from xtylearner.data import load_twins
+from xtylearner.models import DeconfounderCFM
+from xtylearner.training import Trainer, ConsoleLogger
+
+
+def main() -> None:
+    ds = load_twins()
+    X, Y, T = ds.tensors
+    T = T.float().unsqueeze(1)
+    loader = DataLoader(
+        torch.utils.data.TensorDataset(X, Y, T), batch_size=512, shuffle=True
+    )
+    model = DeconfounderCFM(d_x=X.size(1), d_y=1, k_t=1)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    logger = ConsoleLogger()
+    trainer = Trainer(model, opt, loader, logger=logger)
+    trainer.fit(2)
+
+    with torch.no_grad():
+        y0 = model.predict_outcome(X, torch.zeros_like(T))
+        y1 = model.predict_outcome(X, torch.ones_like(T))
+    ite_pred = (y1 - y0).squeeze(1)
+    print("PEHE", torch.sqrt(((ite_pred - 2.0) ** 2).mean()).item())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/test_deconfounder.py
+++ b/tests/models/test_deconfounder.py
@@ -1,0 +1,63 @@
+import torch
+
+from xtylearner.models import DeconfounderCFM
+from xtylearner.models.deconfounder_model import _hsic
+
+
+def generate_data(n=50, k_t=2, d_z=3):
+    z = torch.randn(n, d_z)
+    A = torch.randn(k_t, d_z)
+    t = z @ A.t() + 0.1 * torch.randn(n, k_t)
+    x = torch.zeros(n, 1)
+    y = z.sum(1, keepdim=True) + t.sum(1, keepdim=True)
+    return x, y, t
+
+
+def test_shapes():
+    x, y, t = generate_data()
+    model = DeconfounderCFM(d_x=1, d_y=1, k_t=2, d_z=3, pretrain_epochs=1)
+    loss = model.loss(x, y, t)
+    assert loss.dim() == 0
+    out = model.predict_outcome(x, t)
+    assert out.shape == (x.size(0), 1)
+
+
+def test_grad_flow():
+    x, y, t = generate_data()
+    model = DeconfounderCFM(d_x=1, d_y=1, k_t=2, d_z=3, pretrain_epochs=1)
+    loss = model.loss(x, y, t)
+    loss.backward()
+    vae_grads = [p.grad.clone() for p in model.vae_t.parameters()]
+    out_grads = [p.grad for p in model.out_net.parameters()]
+    assert all(g is not None and g.abs().sum() > 0 for g in vae_grads)
+    assert all(g is None for g in out_grads)
+    for p in model.parameters():
+        p.grad = None
+    model.on_epoch_end()
+    loss = model.loss(x, y, t)
+    loss.backward()
+    out_grads = [p.grad for p in model.out_net.parameters()]
+    assert any(g is not None and g.abs().sum() > 0 for g in out_grads)
+
+
+def test_missing_t():
+    x, y, t = generate_data()
+    t[0, 0] = float("nan")
+    model = DeconfounderCFM(d_x=1, d_y=1, k_t=2, d_z=3, pretrain_epochs=0)
+    loss = model.loss(x, y, t)
+    assert torch.isfinite(loss)
+
+
+def test_ppc_hsic_small():
+    x, y, t = generate_data(n=80)
+    model = DeconfounderCFM(d_x=1, d_y=1, k_t=2, d_z=3, pretrain_epochs=5)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-2)
+    for _ in range(6):
+        loss = model.loss(x, y, t)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+    with torch.no_grad():
+        z = model.vae_t.encode(t, sample=False)
+        hsic = _hsic(t, z).item()
+    assert hsic < 1.0

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -22,6 +22,7 @@ from .vat import VAT_Model
 from .fixmatch import FixMatch
 from .ss_dml import SSDMLModel
 from .ganite import GANITE
+from .deconfounder_model import DeconfounderCFM
 from .registry import get_model, get_model_names, get_model_args
 
 __all__ = [
@@ -49,6 +50,7 @@ __all__ = [
     "FixMatch",
     "SSDMLModel",
     "GANITE",
+    "DeconfounderCFM",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/components.py
+++ b/xtylearner/models/components.py
@@ -1,0 +1,60 @@
+"""Shared network components for causal factor models."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .layers import make_mlp
+
+
+class VAE_T(nn.Module):
+    """Simple VAE over multi-cause treatments with masked reconstruction."""
+
+    def __init__(self, k_t: int, d_z: int, hidden: int = 64) -> None:
+        super().__init__()
+        self.enc_mu = make_mlp([k_t, hidden, hidden, d_z])
+        self.enc_log = make_mlp([k_t, hidden, hidden, d_z])
+        self.dec = make_mlp([d_z, hidden, hidden, k_t])
+        self.d_z = d_z
+
+    # ------------------------------------------------------------------
+    def encode(self, t: torch.Tensor, *, sample: bool = True) -> torch.Tensor:
+        t_filled = torch.nan_to_num(t, 0.0)
+        mu = self.enc_mu(t_filled)
+        logv = self.enc_log(t_filled).clamp(-8, 8)
+        if sample:
+            std = torch.exp(0.5 * logv)
+            z = mu + std * torch.randn_like(std)
+        else:
+            z = mu
+        return z
+
+    # ------------------------------------------------------------------
+    def elbo(self, t: torch.Tensor) -> torch.Tensor:
+        mask = torch.isfinite(t)
+        t_filled = torch.nan_to_num(t, 0.0)
+        mu = self.enc_mu(t_filled)
+        logv = self.enc_log(t_filled).clamp(-8, 8)
+        std = torch.exp(0.5 * logv)
+        z = mu + std * torch.randn_like(std)
+        recon = self.dec(z)
+        recon_loss = 0.5 * ((recon - t_filled) ** 2)
+        recon_loss = (recon_loss * mask.float()).sum(-1).mean()
+        kl = -0.5 * (1 + logv - mu.pow(2) - logv.exp()).sum(-1).mean()
+        return recon_loss + kl
+
+
+class OutcomeNet(nn.Module):
+    """Simple MLP outcome head used by :class:`DeconfounderCFM`."""
+
+    def __init__(self, d_in: int, d_out: int, hidden: int = 64) -> None:
+        super().__init__()
+        self.net = make_mlp([d_in, hidden, hidden, d_out])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        """Apply the MLP to ``x``."""
+        return self.net(x)
+
+
+__all__ = ["VAE_T", "OutcomeNet"]

--- a/xtylearner/models/deconfounder_model.py
+++ b/xtylearner/models/deconfounder_model.py
@@ -1,0 +1,91 @@
+"""Two-stage deconfounder / causal-factor model."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .components import VAE_T, OutcomeNet
+from .registry import register_model
+
+
+def _hsic(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Compute an unbiased HSIC estimate with RBF kernels."""
+    n = x.size(0)
+    xx = (x.unsqueeze(1) - x.unsqueeze(0)).pow(2).sum(-1)
+    yy = (y.unsqueeze(1) - y.unsqueeze(0)).pow(2).sum(-1)
+    kx = torch.exp(-xx / x.size(1))
+    ky = torch.exp(-yy / y.size(1))
+    h = torch.eye(n, device=x.device) - torch.full((n, n), 1.0 / n, device=x.device)
+    kxc = h @ kx @ h
+    kyc = h @ ky @ h
+    return (kxc * kyc).sum() / (n - 1) ** 2
+
+
+@register_model("deconfounder_cfm")
+class DeconfounderCFM(nn.Module):
+    """Two-stage causal-factor model with substitute confounder."""
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k_t: int,
+        d_z: int = 16,
+        hidden: int = 64,
+        pretrain_epochs: int = 50,
+        ppc_freq: int = 25,
+    ) -> None:
+        super().__init__()
+        self.vae_t = VAE_T(k_t, d_z, hidden)
+        self.out_net = OutcomeNet(d_x + d_z + k_t, d_y, hidden)
+        self.register_buffer("epoch", torch.zeros(1, dtype=torch.long))
+        self.pretrain_epochs = pretrain_epochs
+        self.ppc_freq = ppc_freq
+
+    # --------------------------------------------------------------
+    def loss(self, x: torch.Tensor, y: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        if self.epoch.item() < self.pretrain_epochs:
+            return self.vae_t.elbo(t)
+        elbo_t = self.vae_t.elbo(t)
+        z = self.vae_t.encode(t, sample=False).detach()
+        inp = torch.cat([x, torch.nan_to_num(t, 0.0), z], 1)
+        pred = self.out_net(inp)
+        loss_y = F.mse_loss(pred, y)
+        return elbo_t + loss_y
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        z = self.vae_t.encode(t, sample=False)
+        inp = torch.cat([x, torch.nan_to_num(t, 0.0), z], 1)
+        return self.out_net(inp)
+
+    @torch.no_grad()
+    def predict_ite(
+        self, x: torch.Tensor, t0: torch.Tensor, t1: torch.Tensor
+    ) -> torch.Tensor:
+        y0 = self.predict_outcome(x, t0)
+        y1 = self.predict_outcome(x, t1)
+        return y1 - y0
+
+    @torch.no_grad()
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Not implemented since the model does not learn ``p(t|x,y)``."""
+
+        raise NotImplementedError(
+            "DeconfounderCFM does not model p(t|x,y); treatment probabilities "
+            "are unavailable."
+        )
+
+    def on_epoch_end(self, t: torch.Tensor | None = None) -> None:
+        self.epoch += 1
+        if t is not None and self.epoch.item() % self.ppc_freq == 0:
+            z = self.vae_t.encode(t, sample=False)
+            ppc = _hsic(torch.nan_to_num(t, 0.0), z)
+            if hasattr(self, "logger"):
+                self.logger.log_scalar("ppc_hsic", float(ppc))
+
+
+__all__ = ["DeconfounderCFM"]


### PR DESCRIPTION
## Summary
- implement `DeconfounderCFM` with treatment VAE and outcome net
- register the model in the module registry
- document the approach and add README entry
- provide an example script on the Twins data
- add unit tests for shapes, gradient flow, missing data and PPC
- stub out `predict_treatment_proba` to satisfy framework interface

## Testing
- `ruff check xtylearner/models/deconfounder_model.py xtylearner/models/components.py examples/deconfounder_twin_pehe.py tests/models/test_deconfounder.py xtylearner/models/__init__.py --fix`
- `black xtylearner/models/deconfounder_model.py xtylearner/models/components.py examples/deconfounder_twin_pehe.py tests/models/test_deconfounder.py xtylearner/models/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e0845bb088324bf91528a79bdae1e