### PR TITLE
Add VACIM model

### DIFF
--- a/tests/generative/test_vacim.py
+++ b/tests/generative/test_vacim.py
@@ -1,0 +1,14 @@
+import torch
+from xtylearner.models import get_model
+
+
+def test_vacim_overfits_toy():
+    x = torch.randn(256, 5)
+    y = torch.randn(256, 1)
+    t = torch.randint(0, 2, (256, 1)).float()
+    t[::3] = float('nan')
+
+    model = get_model('vacim', d_x=5, d_y=1, k=2)
+    out = model.loss(x, y, t)
+    out['loss'].backward()
+    assert not torch.isnan(out['loss'])

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -25,6 +25,7 @@ from .fixmatch import FixMatch
 from .ss_dml import SSDMLModel
 from .ganite import GANITE
 from .deconfounder_model import DeconfounderCFM
+from .vacim_model import VACIM
 from .registry import get_model, get_model_names, get_model_args
 
 __all__ = [
@@ -55,6 +56,7 @@ __all__ = [
     "DeconfounderCFM",
     "GNN_SCM",
     "DiffusionGNN_SCM",
+    "VACIM",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/generative.py
+++ b/xtylearner/models/generative.py
@@ -8,6 +8,7 @@ from .diffusion_cevae import DiffusionCEVAE
 from .bridge_diff import BridgeDiff
 from .lt_flow_diff import LTFlowDiff
 from .energy_diffusion_imputer import EnergyDiffusionImputer
+from .vacim_model import VACIM
 
 __all__ = [
     "M2VAE",
@@ -18,4 +19,5 @@ __all__ = [
     "BridgeDiff",
     "LTFlowDiff",
     "EnergyDiffusionImputer",
+    "VACIM",
 ]

--- a/xtylearner/models/utils.py
+++ b/xtylearner/models/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import torch
+import torch.nn.functional as F
 
 
 def ramp_up_sigmoid(epoch: int, ramp: int, max_val: float = 1.0) -> float:
@@ -9,4 +11,46 @@ def ramp_up_sigmoid(epoch: int, ramp: int, max_val: float = 1.0) -> float:
     return max_val * math.exp(-5 * (1 - t) ** 2)
 
 
-__all__ = ["ramp_up_sigmoid"]
+def reparameterise(mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
+    """Reparameterisation trick ``z = mu + sigma * eps``."""
+
+    std = (0.5 * logvar).exp()
+    eps = torch.randn_like(std)
+    return mu + eps * std
+
+
+def kl_normal(
+    mu_q: torch.Tensor,
+    logvar_q: torch.Tensor,
+    mu_p: torch.Tensor,
+    logvar_p: torch.Tensor,
+) -> torch.Tensor:
+    """KL divergence ``KL(q||p)`` for diagonal Gaussians."""
+
+    return 0.5 * (
+        logvar_p
+        - logvar_q
+        + (logvar_q.exp() + (mu_q - mu_p).pow(2)) / logvar_p.exp()
+        - 1.0
+    ).sum(1)
+
+
+def gumbel_softmax(
+    logits: torch.Tensor, tau: float, hard: bool = False
+) -> torch.Tensor:
+    return F.gumbel_softmax(logits, tau=tau, hard=hard)
+
+
+def log_categorical(t: torch.Tensor, logits: torch.Tensor) -> torch.Tensor:
+    if t.dim() == 1 or t.size(1) == 1:
+        t = F.one_hot(t.to(torch.long).view(-1), logits.size(-1)).float()
+    return (t * F.log_softmax(logits, 1)).sum(1)
+
+
+__all__ = [
+    "ramp_up_sigmoid",
+    "reparameterise",
+    "kl_normal",
+    "gumbel_softmax",
+    "log_categorical",
+]

--- a/xtylearner/models/vacim_model.py
+++ b/xtylearner/models/vacim_model.py
@@ -1,0 +1,131 @@
+"""Variational Auto-encoder with Conditional Integrated Masking (VACIM)."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .registry import register_model
+from .utils import reparameterise, kl_normal, gumbel_softmax, log_categorical
+
+
+class MLP(nn.Sequential):
+    """Simple multi-layer perceptron used for encoders/decoders."""
+
+    def __init__(self, dims: list[int]) -> None:
+        layers = []
+        for a, b in zip(dims[:-2], dims[1:-1]):
+            layers += [nn.Linear(a, b), nn.ReLU()]
+        layers.append(nn.Linear(dims[-2], dims[-1]))
+        super().__init__(*layers)
+
+
+@register_model("vacim")
+class VACIM(nn.Module):
+    """CEVAE variant with an additional partial encoder and treatment guide."""
+
+    k: int
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k: int,
+        d_z: int = 20,
+        hidden: int = 128,
+        n_mc: int = 5,
+        temp_init: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.k, self.n_mc = k, n_mc
+        self.temperature = temp_init
+        # inference networks
+        self.enc_z_full = MLP([d_x + k + d_y, hidden, hidden, 2 * d_z])
+        self.enc_z_part = MLP([d_x + d_y, hidden, hidden, 2 * d_z])
+        self.enc_t = MLP([d_x + d_y + d_z, hidden, hidden, k])
+        # generative networks
+        self.prior_z = MLP([d_x, hidden, hidden, 2 * d_z])
+        self.dec_t = MLP([d_x + d_z, hidden, hidden, k])
+        self.dec_y = MLP([d_x + k + d_z, hidden, hidden, 2 * d_y])
+        self.d_y, self.d_z = d_y, d_z
+
+    # --------------------------------------------------------------
+    def elbo_observed(
+        self, x: torch.Tensor, t_onehot: torch.Tensor, y: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        z_mu, z_logvar = self.enc_z_full(torch.cat([x, t_onehot, y], 1)).chunk(2, 1)
+        z = reparameterise(z_mu, z_logvar)
+        pz_mu, pz_logvar = self.prior_z(x).chunk(2, 1)
+
+        y_mu, y_logvar = self.dec_y(torch.cat([x, t_onehot, z], 1)).chunk(2, 1)
+        log_py = -0.5 * ((y - y_mu) ** 2 / torch.exp(y_logvar) + y_logvar).sum(1)
+        log_pt = log_categorical(t_onehot, self.dec_t(torch.cat([x, z], 1)))
+
+        kl_z = kl_normal(z_mu, z_logvar, pz_mu, pz_logvar)
+        return log_py + log_pt - kl_z, y_mu
+
+    def elbo_missing(
+        self, x: torch.Tensor, y: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        z_mu, z_logvar = self.enc_z_part(torch.cat([x, y], 1)).chunk(2, 1)
+        elbo = x.new_zeros(len(x))
+        y_hat = x.new_zeros(len(x), self.d_y)
+        t_prob = x.new_zeros(len(x), self.k)
+        for _ in range(self.n_mc):
+            z = reparameterise(z_mu, z_logvar)
+            t_logits = self.enc_t(torch.cat([x, y, z], 1))
+            t_soft = gumbel_softmax(t_logits, self.temperature, hard=False)
+            zc_mu, zc_logvar = self.enc_z_full(torch.cat([x, t_soft, y], 1)).chunk(2, 1)
+            zc = reparameterise(zc_mu, zc_logvar)
+            pz_mu, pz_logvar = self.prior_z(x).chunk(2, 1)
+
+            y_mu, y_logvar = self.dec_y(torch.cat([x, t_soft, zc], 1)).chunk(2, 1)
+            log_py = -0.5 * ((y - y_mu) ** 2 / torch.exp(y_logvar) + y_logvar).sum(1)
+            log_pt = (t_soft * F.log_softmax(self.dec_t(torch.cat([x, zc], 1)), 1)).sum(1)
+            log_qt = (t_soft * F.log_softmax(t_logits, 1)).sum(1)
+            kl_z = kl_normal(zc_mu, zc_logvar, pz_mu, pz_logvar)
+            elbo += (log_py + log_pt - log_qt - kl_z) / self.n_mc
+            y_hat += y_mu / self.n_mc
+            t_prob += torch.softmax(t_logits, 1) / self.n_mc
+        return elbo, y_hat, t_prob
+
+    # --------------------------------------------------------------
+    def loss(
+        self, x: torch.Tensor, y: torch.Tensor, t: torch.Tensor | None = None
+    ) -> dict[str, torch.Tensor]:
+        """Compute negative ELBO for a batch."""
+
+        if t is None:
+            mask = torch.zeros(len(x), dtype=torch.bool, device=x.device)
+            t_obs = None
+        else:
+            mask = ~torch.isnan(t[:, 0])
+            t_obs = t[mask]
+            if t_obs.dim() == 2 and t_obs.size(1) == 1:
+                t_obs = t_obs.squeeze(1)
+
+        elbo = x.new_zeros(len(x))
+        y_pred = x.new_zeros(len(x), self.d_y)
+        t_imp = x.new_zeros(len(x), self.k)
+
+        if mask.any():
+            t_onehot = F.one_hot(t_obs.to(torch.long), self.k).float()
+            e, y_hat = self.elbo_observed(x[mask], t_onehot, y[mask])
+            elbo[mask], y_pred[mask] = e, y_hat
+        if (~mask).any():
+            e, y_hat, t_prob = self.elbo_missing(x[~mask], y[~mask])
+            elbo[~mask], y_pred[~mask], t_imp[~mask] = e, y_hat, t_prob
+
+        self.temperature = max(0.5, self.temperature * 0.999)
+        return {"loss": -elbo.mean(), "y_hat": y_pred, "t_prob": t_imp}
+
+    # --------------------------------------------------------------
+    @staticmethod
+    def add_model_specific_args(parser):
+        parser.add_argument("--n_mc", type=int, default=5)
+        parser.add_argument("--temp_init", type=float, default=1.0)
+        return parser
+
+
+__all__ = ["VACIM"]


### PR DESCRIPTION
## Summary
- implement VACIM generative model with missing-treatment handling
- expose VACIM through model registry
- add helper functions for reparameterisation and categorical log-probs
- include simple VACIM unit test

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3ee414488324bc3e229ee1f5495b