### PR TITLE
Fix DiffusionCEVAE trainer predictions

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,4 @@
 import torch
-import yaml
 import pytest
 from torch.utils.data import DataLoader, TensorDataset
 

--- a/xtylearner/models/diffusion_cevae.py
+++ b/xtylearner/models/diffusion_cevae.py
@@ -183,6 +183,7 @@ class DiffusionCEVAE(nn.Module):
     ) -> None:
         super().__init__()
         self.k = k
+        self.d_u = d_u
         self.timesteps = timesteps
         self.sigma_min = sigma_min
         self.sigma_max = sigma_max
@@ -272,6 +273,8 @@ class DiffusionCEVAE(nn.Module):
         """Approximate ``p(t|x,y)`` using the encoder and decoder."""
 
         b = x.size(0)
+        if y.ndim == 1:
+            y = y.unsqueeze(-1)
         t_dummy = torch.full((b,), -1, dtype=torch.long, device=x.device)
         mu, _ = self.enc_u(x, t_dummy, y)
         logits = self.dec_t(x, mu)

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -6,7 +6,7 @@ import torch
 from torch.nn.functional import one_hot
 
 from .base_trainer import BaseTrainer
-from ..models.generative import M2VAE, SS_CEVAE
+from ..models.generative import M2VAE, SS_CEVAE, DiffusionCEVAE
 
 
 class GenerativeTrainer(BaseTrainer):
@@ -56,6 +56,11 @@ class GenerativeTrainer(BaseTrainer):
     def predict(self, x: torch.Tensor, t_val: int) -> torch.Tensor:
         self.model.eval()
         with torch.no_grad():
+            if isinstance(self.model, DiffusionCEVAE):
+                u = torch.randn(x.size(0), self.model.d_u, device=self.device)
+                t = torch.full((x.size(0),), t_val, device=self.device)
+                return self.model.dec_y(x.to(self.device), t, u)
+
             z_dim = self.model.enc_z.net_mu[-1].out_features
             z = torch.randn(x.size(0), z_dim, device=self.device)
             t1h = one_hot(


### PR DESCRIPTION
## Summary
- handle DiffusionCEVAE in `GenerativeTrainer.predict`
- allow 1D outcome tensors in `DiffusionCEVAE.predict_treatment_proba`
- expose latent dimension via `DiffusionCEVAE.d_u`
- remove unused import in tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f157231ac8324adb25d6ccbd3a28d