### PR TITLE
Fix VACIM trainer integration

### DIFF
--- a/xtylearner/training/base_trainer.py
+++ b/xtylearner/training/base_trainer.py
@@ -62,7 +62,16 @@ class BaseTrainer(ABC):
         if isinstance(loss, torch.Tensor):
             return {"loss": float(loss.item())}
         if isinstance(loss, Mapping):
-            return {k: float(v) for k, v in loss.items()}
+            metrics: dict[str, float] = {}
+            for k, v in loss.items():
+                if isinstance(v, torch.Tensor) and v.numel() == 1:
+                    metrics[k] = float(v.item())
+                elif not isinstance(v, torch.Tensor):
+                    try:
+                        metrics[k] = float(v)
+                    except Exception:
+                        pass
+            return metrics
         return {"loss": float(loss)}
 
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `VACIM.loss` return a dict with only a scalar loss
- add outcome and treatment prediction helpers to `VACIM`
- skip non-scalar values when gathering trainer metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f31180d548324b36a0c4cc4f6ed70