### PR TITLE
Allow scheduler tuples for GANITE trainer

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -238,6 +238,27 @@ def test_ganite_trainer_runs():
     assert isinstance(loss, float)
 
 
+def test_ganite_with_schedulers():
+    dataset = load_mixed_synthetic_dataset(
+        n_samples=20, d_x=2, seed=18, label_ratio=0.5
+    )
+    loader = DataLoader(dataset, batch_size=5)
+    model = GANITE(d_x=2, d_y=1)
+    opt_g = torch.optim.SGD(model.parameters(), lr=0.1)
+    opt_d = torch.optim.SGD(model.parameters(), lr=0.1)
+    sched_g = torch.optim.lr_scheduler.StepLR(opt_g, step_size=1, gamma=0.1)
+    sched_d = torch.optim.lr_scheduler.StepLR(opt_d, step_size=1, gamma=0.1)
+    trainer = Trainer(
+        model,
+        (opt_g, opt_d),
+        loader,
+        scheduler=(sched_g, sched_d),
+    )
+    trainer.fit(2)
+    assert opt_g.param_groups[0]["lr"] == pytest.approx(0.001, rel=1e-6)
+    assert opt_d.param_groups[0]["lr"] == pytest.approx(0.001, rel=1e-6)
+
+
 def test_predict_treatment_proba():
     dataset = load_toy_dataset(n_samples=6, d_x=2, seed=12)
     loader = DataLoader(dataset, batch_size=6)

--- a/xtylearner/training/base_trainer.py
+++ b/xtylearner/training/base_trainer.py
@@ -26,7 +26,14 @@ class BaseTrainer(ABC):
         val_loader: Optional[Iterable] = None,
         device: str = "cpu",
         logger: Optional[TrainerLogger] = None,
-        scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
+        scheduler: (
+            torch.optim.lr_scheduler._LRScheduler
+            | tuple[
+                torch.optim.lr_scheduler._LRScheduler,
+                torch.optim.lr_scheduler._LRScheduler,
+            ]
+            | None
+        ) = None,
         grad_clip_norm: float | None = None,
     ) -> None:
         # Some simple models (e.g. probabilistic circuits) do not inherit from

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -26,7 +26,14 @@ class Trainer:
         val_loader: Optional[Iterable] = None,
         device: str = "cpu",
         logger: Optional[TrainerLogger] = None,
-        scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
+        scheduler: (
+            torch.optim.lr_scheduler._LRScheduler
+            | tuple[
+                torch.optim.lr_scheduler._LRScheduler,
+                torch.optim.lr_scheduler._LRScheduler,
+            ]
+            | None
+        ) = None,
         grad_clip_norm: float | None = None,
     ) -> None:
         trainer_cls = self._select_trainer(model)


### PR DESCRIPTION
## Summary
- support tuples of schedulers in the `AdversarialTrainer`
- adjust `Trainer` and `BaseTrainer` to accept scheduler tuples
- test GANITE training with paired schedulers

## Testing
- `ruff check xtylearner/training/adversarial.py xtylearner/training/trainer.py xtylearner/training/base_trainer.py tests/test_trainer.py`
- `black xtylearner/training/adversarial.py xtylearner/training/trainer.py xtylearner/training/base_trainer.py tests/test_trainer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f50bd21c48324a3854051f6383c40