### PR TITLE
Add regressor support to LP_KNN baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ The model registry exposes a variety of architectures grouped below by type.
 
 #### Semi-Supervised Baselines
 
-- ``LP_KNN`` – a k-nearest neighbour label propagation baseline.
+- ``LP_KNN`` – a k-nearest neighbour label propagation baseline that can
+  optionally train a scikit-learn regressor on the propagated labels.
 - ``MeanTeacher`` – an exponential moving average teacher model for
   consistency training.
 - ``VIME`` – a two-stage self-supervised method for tabular data.

--- a/tests/models/test_labelprop.py
+++ b/tests/models/test_labelprop.py
@@ -1,0 +1,19 @@
+from sklearn.linear_model import LinearRegression
+
+from xtylearner.data import load_mixed_synthetic_dataset, load_synthetic_dataset
+from xtylearner.models import LP_KNN
+
+
+def test_lp_knn_regressor_metrics():
+    train = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=0, label_ratio=0.7)
+    val = load_synthetic_dataset(n_samples=10, d_x=2, seed=1)
+    Xtr, Ytr, Ttr = train.tensors
+    Xv, Yv, Tv = val.tensors
+    model = LP_KNN(n_neighbors=3, regressor=LinearRegression())
+    model.fit(Xtr.numpy(), Ytr.squeeze(-1).numpy(), Ttr.numpy())
+    metrics = model.regressor_metrics(
+        Xtr.numpy(), Ytr.squeeze(-1).numpy(), Ttr.numpy(),
+        Xv.numpy(), Yv.squeeze(-1).numpy(), Tv.numpy()
+    )
+    assert set(metrics) == {"val_acc", "rmse_labelled", "rmse_full"}
+    assert all(isinstance(v, float) for v in metrics.values())

--- a/xtylearner/models/labelprop.py
+++ b/xtylearner/models/labelprop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+from sklearn.base import clone
 from sklearn.semi_supervised import LabelPropagation
 
 from .registry import register_model
@@ -22,13 +24,21 @@ class LP_KNN:
     target = "treatment"
     requires_outcome = False
 
-    def __init__(self, n_neighbors: int = 10):
+    def __init__(self, n_neighbors: int = 10, regressor=None):
         self.clf = LabelPropagation(kernel="knn", n_neighbors=n_neighbors)
+        self.regressor = regressor
+        self.k = None
 
     # ------------------------------------------------------------------
     def fit(self, X, y, t_obs=None):
         target = t_obs if t_obs is not None else y
         self.clf.fit(X, target)
+        self.k = len(self.clf.classes_)
+
+        if self.regressor is not None:
+            t_full = self.clf.transduction_
+            X_reg = np.concatenate([X, self._one_hot(t_full)], axis=1)
+            self.regressor.fit(X_reg, y)
         return self
 
     # ------------------------------------------------------------------
@@ -41,3 +51,64 @@ class LP_KNN:
 
     # ``ArrayTrainer`` looks for this method when computing metrics.
     predict_treatment_proba = predict_proba
+
+    # ------------------------------------------------------------------
+    def _one_hot(self, t):
+        if self.k is None:
+            raise ValueError("Model not fitted")
+        t = np.asarray(t, dtype=int)
+        return np.eye(self.k)[t]
+
+    # ------------------------------------------------------------------
+    def predict_outcome(self, X, t):
+        if self.regressor is None:
+            raise ValueError("No regressor provided")
+        t_arr = np.asarray(t, dtype=int)
+        X_reg = np.concatenate([X, self._one_hot(t_arr)], axis=1)
+        return self.regressor.predict(X_reg)
+
+    # ------------------------------------------------------------------
+    def regressor_metrics(
+        self,
+        X_train: np.ndarray,
+        Y_train: np.ndarray,
+        T_obs: np.ndarray,
+        X_val: np.ndarray,
+        Y_val: np.ndarray,
+        T_val: np.ndarray,
+    ) -> dict[str, float]:
+        """Return metrics comparing labelled vs full-data regressors."""
+
+        if self.regressor is None:
+            return {}
+
+        mask = T_obs != -1
+        if mask.any():
+            reg_lab = clone(self.regressor)
+            reg_lab.fit(
+                np.concatenate([X_train[mask], self._one_hot(T_obs[mask])], axis=1),
+                Y_train[mask],
+            )
+            pred_lab = reg_lab.predict(
+                np.concatenate([X_val, self._one_hot(T_val)], axis=1)
+            )
+            rmse_lab = float(np.sqrt(((pred_lab - Y_val) ** 2).mean()))
+        else:
+            rmse_lab = float("nan")
+
+        pred_full = self.predict_outcome(X_val, T_val)
+        rmse_full = float(np.sqrt(((pred_full - Y_val) ** 2).mean()))
+
+        mask_val = T_val != -1
+        if mask_val.any():
+            acc = float(
+                (self.predict(X_val[mask_val]) == T_val[mask_val]).mean()
+            )
+        else:
+            acc = float("nan")
+
+        return {
+            "val_acc": acc,
+            "rmse_labelled": rmse_lab,
+            "rmse_full": rmse_full,
+        }

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -75,6 +75,9 @@ class ArrayTrainer(BaseTrainer):
                         torch.from_numpy(Tv),
                     )
                 )
+                if hasattr(self.model, "regressor_metrics"):
+                    extra = self.model.regressor_metrics(X, Y, T_obs, Xv, Yv, Tv)
+                    val_metrics.update(extra)
                 self.logger.log_validation(1, val_metrics)
             self.logger.end_epoch(1)
 


### PR DESCRIPTION
## Summary
- allow `lp_knn` to train a scikit regressor using propagated labels
- provide helper to compare RMSE between labelled-only and full-data regressors
- log these metrics in `ArrayTrainer`
- document new functionality and add regression test

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f704bd328832496226b890a3ca81a