### PR TITLE
Improve public API docstrings

### DIFF
--- a/xtylearner/data/ihdp_dataset.py
+++ b/xtylearner/data/ihdp_dataset.py
@@ -27,7 +27,20 @@ def load_ihdp(
     split: Literal["train", "test"] = "train",
     data_dir: str = "~/.xtylearner/data",
 ) -> TensorDataset:
-    """Download (if needed) and load the IHDP dataset."""
+    """Load the IHDP dataset, downloading it on demand.
+
+    Parameters
+    ----------
+    split:
+        Which portion of the dataset to load, ``"train"`` or ``"test"``.
+    data_dir:
+        Directory where the ``.npz`` files are stored or should be downloaded to.
+
+    Returns
+    -------
+    TensorDataset
+        Dataset ``(X, Y, T)`` with shapes ``(N, d_x)``, ``(N, 1)`` and ``(N,)``.
+    """
 
     url = URLS[split]
     path = Path(data_dir).expanduser()

--- a/xtylearner/data/mixed_synthetic_dataset.py
+++ b/xtylearner/data/mixed_synthetic_dataset.py
@@ -18,6 +18,12 @@ def load_mixed_synthetic_dataset(
 
     Parameters
     ----------
+    n_samples:
+        Total number of samples to generate.
+    d_x:
+        Dimensionality of the covariates.
+    seed:
+        Seed controlling both dataset generation and label masking.
     label_ratio:
         Fraction of samples with observed treatment labels.
 

--- a/xtylearner/data/synthetic_dataset.py
+++ b/xtylearner/data/synthetic_dataset.py
@@ -19,7 +19,23 @@ def load_synthetic_dataset(
     d_x: int = 5,
     seed: int = 0,
 ) -> TensorDataset:
-    """Generate a moderately sized synthetic benchmark dataset."""
+    """Generate a simple synthetic benchmark dataset.
+
+    Parameters
+    ----------
+    n_samples:
+        Number of observations to generate.
+    d_x:
+        Dimensionality of the covariates ``X``.
+    seed:
+        Random seed controlling reproducibility.
+
+    Returns
+    -------
+    TensorDataset
+        Dataset ``(X, Y, T)`` with shapes ``(n_samples, d_x)``, ``(n_samples, 1)``
+        and ``(n_samples,)``.
+    """
 
     rng = np.random.default_rng(seed)
     X, _ = make_regression(

--- a/xtylearner/data/tabular_dataset.py
+++ b/xtylearner/data/tabular_dataset.py
@@ -35,10 +35,10 @@ def load_tabular_dataset(
     Returns
     -------
     TensorDataset
-        Dataset of ``(X, Y, T)`` tensors.
-        When ``T`` contains string categories, a ``treatment_mapping``
-        attribute on the returned dataset stores the category-to-index
-        mapping.
+        Dataset of ``(X, Y, T)`` tensors. Columns not designated as outcome or
+        treatment become covariates ``X`` in the original order. When ``T``
+        contains string categories, a ``treatment_mapping`` attribute on the
+        returned dataset stores the category-to-index mapping.
     """
 
     if isinstance(data, (str, Path)):

--- a/xtylearner/data/twins_dataset.py
+++ b/xtylearner/data/twins_dataset.py
@@ -21,7 +21,18 @@ URL = "https://raw.githubusercontent.com/py-why/benchmark-datasets/main/twins/tw
 
 
 def load_twins(data_dir: str = "~/.xtylearner/data") -> TensorDataset:
-    """Download (if necessary) and load the Twins dataset."""
+    """Load the Twins dataset, downloading a processed CSV if needed.
+
+    Parameters
+    ----------
+    data_dir:
+        Location used to cache the dataset file.
+
+    Returns
+    -------
+    TensorDataset
+        Dataset ``(X, Y, T)`` with shapes ``(N, d_x)``, ``(N, 1)`` and ``(N,)``.
+    """
 
     path = Path(data_dir).expanduser()
     path.mkdir(parents=True, exist_ok=True)

--- a/xtylearner/models/registry.py
+++ b/xtylearner/models/registry.py
@@ -9,7 +9,18 @@ _MODEL_REGISTRY: Dict[str, Callable[..., Any]] = {}
 
 
 def register_model(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorator to register a model class under ``name``."""
+    """Register ``cls`` under ``name`` so it can be constructed later.
+
+    Parameters
+    ----------
+    name:
+        Identifier used with :func:`get_model`.
+
+    Returns
+    -------
+    Callable[[Callable[..., Any]], Callable[..., Any]]
+        A decorator that adds the class to the registry unchanged.
+    """
 
     def decorator(cls: Callable[..., Any]) -> Callable[..., Any]:
         _MODEL_REGISTRY[name] = cls
@@ -19,20 +30,44 @@ def register_model(name: str) -> Callable[[Callable[..., Any]], Callable[..., An
 
 
 def get_model(name: str, **hparams: Any) -> Any:
-    """Instantiate a model from the registry."""
+    """Instantiate a registered model.
+
+    Parameters
+    ----------
+    name:
+        Model identifier previously passed to :func:`register_model`.
+    **hparams:
+        Keyword arguments forwarded to the model constructor.
+
+    Returns
+    -------
+    Any
+        A newly created model instance.
+    """
     if name not in _MODEL_REGISTRY:
         raise ValueError(f"Unknown model '{name}'. Available: {list(_MODEL_REGISTRY)}")
     return _MODEL_REGISTRY[name](**hparams)
 
 
 def get_model_names() -> list[str]:
-    """Return a sorted list of registered model names."""
+    """List names of all registered models in alphabetical order."""
 
     return sorted(_MODEL_REGISTRY)
 
 
 def get_model_args(name: str) -> List[str]:
-    """Return the constructor argument names for a registered model."""
+    """Return the argument names for ``name``'s constructor.
+
+    Parameters
+    ----------
+    name:
+        Identifier of a registered model.
+
+    Returns
+    -------
+    list[str]
+        Positional parameter names excluding ``self``.
+    """
 
     if name not in _MODEL_REGISTRY:
         raise ValueError(

--- a/xtylearner/models/utils.py
+++ b/xtylearner/models/utils.py
@@ -6,13 +6,28 @@ import torch.nn.functional as F
 
 
 def ramp_up_sigmoid(epoch: int, ramp: int, max_val: float = 1.0) -> float:
-    """Sigmoid ramp-up used for VAT and Mean Teacher baselines."""
+    """Sigmoid-shaped ramp used for curriculum schedules.
+
+    Parameters
+    ----------
+    epoch:
+        Current training epoch.
+    ramp:
+        Duration of the ramp in epochs.
+    max_val:
+        Maximum value attained after ``ramp`` epochs.
+
+    Returns
+    -------
+    float
+        Scaling factor in ``[0, max_val]``.
+    """
     t = min(epoch / ramp, 1.0)
     return max_val * math.exp(-5 * (1 - t) ** 2)
 
 
 def reparameterise(mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
-    """Reparameterisation trick ``z = mu + sigma * eps``."""
+    """Sample ``z`` using the reparameterisation trick ``z = mu + sigma * eps``."""
 
     std = (0.5 * logvar).exp()
     eps = torch.randn_like(std)
@@ -25,7 +40,7 @@ def kl_normal(
     mu_p: torch.Tensor,
     logvar_p: torch.Tensor,
 ) -> torch.Tensor:
-    """KL divergence ``KL(q||p)`` for diagonal Gaussians."""
+    """KL divergence ``KL(q‖p)`` for diagonal-covariance Gaussians."""
 
     return 0.5 * (
         logvar_p
@@ -38,10 +53,14 @@ def kl_normal(
 def gumbel_softmax(
     logits: torch.Tensor, tau: float, hard: bool = False
 ) -> torch.Tensor:
+    """Sample from the Gumbel-Softmax distribution."""
+
     return F.gumbel_softmax(logits, tau=tau, hard=hard)
 
 
 def log_categorical(t: torch.Tensor, logits: torch.Tensor) -> torch.Tensor:
+    """Log-probability of labels ``t`` under categorical ``logits``."""
+
     if t.dim() == 1 or t.size(1) == 1:
         t = F.one_hot(t.to(torch.long).view(-1), logits.size(-1)).float()
     return (t * F.log_softmax(logits, 1)).sum(1)

--- a/xtylearner/training/metrics.py
+++ b/xtylearner/training/metrics.py
@@ -7,31 +7,35 @@ import torch.nn.functional as F
 
 
 def mse_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Mean squared error."""
+    """Mean squared error between ``pred`` and ``target``.
+
+    Both tensors must be broadcastable to the same shape.
+    Returns the average of squared differences as a scalar tensor.
+    """
 
     return F.mse_loss(pred, target)
 
 
 def mae_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Mean absolute error."""
+    """Mean absolute error between ``pred`` and ``target``."""
 
     return torch.mean(torch.abs(pred - target))
 
 
 def rmse_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Root mean squared error."""
+    """Root mean squared error of ``pred`` compared with ``target``."""
 
     return torch.sqrt(mse_loss(pred, target))
 
 
 def cross_entropy_loss(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Cross entropy for classification."""
+    """Cross entropy between ``logits`` and integer class labels ``target``."""
 
     return F.cross_entropy(logits, target)
 
 
 def accuracy(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Classification accuracy for ``logits`` compared with ``target``."""
+    """Classification accuracy comparing argmax of ``logits`` and ``target``."""
 
     pred = logits.argmax(dim=-1)
     return (pred == target).float().mean()


### PR DESCRIPTION
## Summary
- expand the documentation for model registry helpers
- clarify dataset loader parameter docs
- add details to training metrics
- document model utility helpers better

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f80155ba0832483d845d9d06fb820