### PR TITLE
Improve docstrings

### DIFF
--- a/xtylearner/models/components.py
+++ b/xtylearner/models/components.py
@@ -20,6 +20,24 @@ class VAE_T(nn.Module):
 
     # ------------------------------------------------------------------
     def encode(self, t: torch.Tensor, *, sample: bool = True) -> torch.Tensor:
+        """Encode observed treatments into a latent code.
+
+        Parameters
+        ----------
+        t:
+            Tensor of shape ``(n, k_t)`` containing possibly masked
+            one-hot treatment labels. ``NaN`` entries are treated as
+            missing values.
+        sample:
+            When ``True`` draw a sample ``z`` from the posterior
+            ``q(z|t)``. If ``False`` the posterior mean is returned.
+
+        Returns
+        -------
+        torch.Tensor
+            Latent representation ``z`` with dimension ``d_z``.
+        """
+
         t_filled = torch.nan_to_num(t, 0.0)
         mu = self.enc_mu(t_filled)
         logv = self.enc_log(t_filled).clamp(-8, 8)
@@ -32,6 +50,8 @@ class VAE_T(nn.Module):
 
     # ------------------------------------------------------------------
     def elbo(self, t: torch.Tensor) -> torch.Tensor:
+        """Return the evidence lower bound for a batch of treatments."""
+
         mask = torch.isfinite(t)
         t_filled = torch.nan_to_num(t, 0.0)
         mu = self.enc_mu(t_filled)

--- a/xtylearner/models/dragon_net.py
+++ b/xtylearner/models/dragon_net.py
@@ -26,12 +26,15 @@ class DragonNet(nn.Module):
 
     # ------------------------------------------------------------------
     def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        """Return outcome prediction ``y`` for covariates ``x`` and treatment ``t``."""
+
         phi = self.encoder(x)
         out = self.outcome_head(phi).view(-1, self.k, self.d_y)
         return out.gather(1, t.view(-1, 1, 1).expand(-1, 1, self.d_y)).squeeze(1)
 
     # ------------------------------------------------------------------
     def loss(self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor) -> torch.Tensor:
+        """Compute the DragonNet training loss for a mini-batch."""
         phi = self.encoder(x)
         mu_hat = self.outcome_head(phi).view(-1, self.k, self.d_y)
         pi_hat = self.propensity_head(phi)
@@ -76,12 +79,16 @@ class DragonNet(nn.Module):
     # ------------------------------------------------------------------
     @torch.no_grad()
     def predict_outcome(self, x: torch.Tensor, t: int) -> torch.Tensor:
+        """Predict outcome for all rows in ``x`` under treatment ``t``."""
+
         phi = self.encoder(x)
         mu = self.outcome_head(phi).view(-1, self.k, self.d_y)
         return mu[:, t, :].squeeze(-1)
 
     @torch.no_grad()
     def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor | None = None) -> torch.Tensor:
+        """Return ``p(t|x)`` or ``p(t|x,y)`` depending on ``y``."""
+
         phi = self.encoder(x)
         if y is None:
             return F.softmax(self.propensity_head(phi), dim=-1)

--- a/xtylearner/scripts/train.py
+++ b/xtylearner/scripts/train.py
@@ -14,11 +14,14 @@ DEFAULT_CFG = Path(__file__).resolve().parent.parent / "configs" / "default.yaml
 
 
 def load_config(path: Path) -> dict:
+    """Load a YAML configuration file and return it as a dictionary."""
+
     with open(path, "r") as f:
         return yaml.safe_load(f)
 
 
 def main() -> None:
+    """Entry point for the ``train.py`` script."""
     parser = argparse.ArgumentParser(description="Train an XTYLearner model")
     parser.add_argument(
         "--model", required=True, help="Model name registered in xtylearner.models"

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -117,6 +117,7 @@ class ArrayTrainer(BaseTrainer):
         return float((preds == target).mean())
 
     def predict(self, x: torch.Tensor, t_val: int | None = None):
+        """Return model predictions for ``x`` as ``numpy`` arrays."""
         X_np = x.cpu().numpy()
         if t_val is not None and hasattr(self.model, "predict_outcome"):
             return self.model.predict_outcome(X_np, t_val)

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -13,6 +13,7 @@ class GenerativeTrainer(BaseTrainer):
     """Trainer for generative models using an ELBO objective."""
 
     def step(self, batch: Iterable[torch.Tensor]) -> torch.Tensor:
+        """Compute the ELBO (or loss) for a single training batch."""
         data = [b.to(self.device) for b in batch]
         if len(data) == 2:
             x, y = data

--- a/xtylearner/training/gnn_trainer.py
+++ b/xtylearner/training/gnn_trainer.py
@@ -6,6 +6,8 @@ class GNNTrainer(GenerativeTrainer):
 
     @staticmethod
     def add_model_specific_args(parser):
+        """Register command line options used by :class:`GNN_SCM`."""
+
         parser.add_argument("--lambda_acyc", type=float, default=10.0)
         parser.add_argument("--gamma_l1", type=float, default=1e-2)
         return parser

--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -11,6 +11,7 @@ class SupervisedTrainer(BaseTrainer):
     """Generic trainer for fully observed models with a ``loss`` method."""
 
     def step(self, batch: Iterable[torch.Tensor]):
+        """Return the model loss for ``batch`` moved to the current device."""
         inputs = [b.to(self.device) for b in batch]
         if len(inputs) == 2:
             x, y = inputs

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -66,6 +66,7 @@ class Trainer:
 
     # ------------------------------------------------------------------
     def _select_trainer(self, model: torch.nn.Module) -> type[BaseTrainer]:
+        """Choose a concrete trainer class based on model capabilities."""
         if hasattr(model, "loss_G") and hasattr(model, "loss_D"):
             return AdversarialTrainer
         if hasattr(model, "elbo"):
@@ -84,15 +85,19 @@ class Trainer:
 
     # ------------------------------------------------------------------
     def fit(self, num_epochs: int) -> None:
+        """Train the wrapped model for ``num_epochs`` epochs."""
         self._trainer.fit(num_epochs)
 
     def evaluate(self, data_loader: Iterable) -> float:
+        """Return the primary metric on ``data_loader``."""
         return self._trainer.evaluate(data_loader)
 
     def predict(self, *args, **kwargs):
+        """Forward to the underlying trainer's ``predict`` method."""
         return self._trainer.predict(*args, **kwargs)
 
     def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Delegated call to ``predict_treatment_proba`` of the inner trainer."""
         return self._trainer.predict_treatment_proba(x, y)
 
     # Expose attributes of the underlying trainer/model


### PR DESCRIPTION
## Summary
- add documentation for VAE_T methods
- document DragonNet public APIs
- clarify generative and supervised trainer steps
- document array trainer prediction
- explain trainer selection heuristics
- document GNNTrainer CLI options
- note configuration and script entry points
- describe stochastic GNN SCM helpers

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8ae456dc8324a58c7ff7cabc7f98