### PR TITLE
Improve docstrings

### DIFF
--- a/xtylearner/models/em_model.py
+++ b/xtylearner/models/em_model.py
@@ -22,12 +22,38 @@ def em_learn(
     regressor_factory=None,
     verbose=False,
 ):
-    """Return:
-    - clf_T      : classifier modelling  p(T | X)
-    - regs_Y[t]  : list of regressors modelling E[Y | X, T=t]
-    - sigma2[t]  : residual variance per treatment
-    - T_imputed  : np.ndarray of shape (n,) with hard EM labels
-    - ll         : complete-data log-likelihood at convergence
+    """Expectation-maximisation training loop.
+
+    Parameters
+    ----------
+    X, Y, T_obs:
+        Arrays containing covariates, outcomes and (possibly missing)
+        treatments.
+    k:
+        Number of treatment categories.
+    max_iter:
+        Maximum number of EM iterations.
+    tol:
+        Stopping tolerance on the complete-data log-likelihood.
+    classifier_factory:
+        Callable returning a scikit-learn classifier for ``p(T|X,Y)``.
+    regressor_factory:
+        Callable returning regressors for ``E[Y|X,T]``.
+    verbose:
+        If ``True`` print log-likelihood progress.
+
+    Returns
+    -------
+    clf_T : ``sklearn.base.ClassifierMixin``
+        Fitted classifier over ``(X,Y)``.
+    regs_Y : list
+        List of regressors predicting ``Y`` given ``X`` and ``T``.
+    sigma2 : np.ndarray
+        Residual variance per treatment.
+    T_imputed : np.ndarray
+        Hard EM labels for ``T``.
+    ll : float
+        Final complete-data log-likelihood.
     """
     # ----- split labelled vs unlabelled ----------------------------------
     labelled = T_obs != -1


### PR DESCRIPTION
## Summary
- expand docstrings across trainer classes and helper functions
- document parameters and return values for FixMatch helpers and EM utilities
- run formatting

## Testing
- `ruff check xtylearner/models/em_model.py xtylearner/models/fixmatch_tabular.py xtylearner/training/adversarial.py xtylearner/training/diffusion.py xtylearner/training/em.py xtylearner/training/generative.py xtylearner/training/supervised.py xtylearner/training/trainer.py`
- `black --check xtylearner/models/em_model.py xtylearner/models/fixmatch_tabular.py xtylearner/training/adversarial.py xtylearner/training/diffusion.py xtylearner/training/em.py xtylearner/training/generative.py xtylearner/training/supervised.py xtylearner/training/trainer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xtylearner')*

------
https://chatgpt.com/codex/tasks/task_e_686f9ed358d88324bbb34c0db695e2bc