### PR TITLE
Add CNFlow model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "torch",
     "scikit-learn",
     "numpy",
-    "nflows",
+    "nflows>=0.16",
     "pyyaml",
     "pandas",
     "scipy",

--- a/tests/test_cnflow.py
+++ b/tests/test_cnflow.py
@@ -1,0 +1,21 @@
+import torch
+
+from xtylearner.models import CNFlowModel
+
+
+def test_shapes():
+    d_x, d_y, k = 5, 2, 3
+    x = torch.randn(17, d_x)
+    y = torch.randn(17, d_y)
+    t = torch.randint(0, k, (17,))
+    mask = torch.randint(0, 2, (17,))
+
+    model = CNFlowModel(d_x=d_x, d_y=d_y, k=k)
+    loss = model.loss(x, y, t, mask)
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert model.predict_outcome(x[:3], t[:3]).shape == (3, d_y)
+    probs = model.predict_treatment_proba(x[:3], y[:3])
+    assert probs.shape == (3, k)
+    assert torch.allclose(probs.sum(-1), torch.ones(3), atol=1e-5)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -27,6 +27,7 @@ from .ss_dml import SSDMLModel
 from .ganite import GANITE
 from .deconfounder_model import DeconfounderCFM
 from .vacim_model import VACIM
+from .cnflow_model import CNFlowModel
 from .registry import get_model, get_model_names, get_model_args
 
 __all__ = [
@@ -59,6 +60,7 @@ __all__ = [
     "GNN_SCM",
     "DiffusionGNN_SCM",
     "VACIM",
+    "CNFlowModel",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/cnflow_model.py
+++ b/xtylearner/models/cnflow_model.py
@@ -1,0 +1,132 @@
+"""Conditional normalising flow for joint modelling of (y,t)|x."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from nflows.flows import Flow
+from nflows.distributions import StandardNormal
+from nflows.transforms import (
+    MaskedAffineAutoregressiveTransform,
+    CompositeTransform,
+    IdentityTransform,
+)
+
+from .registry import register_model
+from .layers import make_mlp
+
+
+@register_model("cnflow")
+class CNFlowModel(nn.Module):
+    """Joint density model ``p(y,t|x)`` using a conditional normalising flow."""
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k: int,
+        hidden: int = 128,
+        n_layers: int = 5,
+    ) -> None:
+        super().__init__()
+        self.k = k
+        self.d_y = d_y
+        self.cond_net = make_mlp([d_x, hidden, hidden], activation=nn.ReLU)
+        self.flow = self._build_conditional_flow(hidden, n_layers)
+
+    # ------------------------------------------------------------
+    def _build_conditional_flow(self, hidden: int, n_layers: int) -> Flow:
+        transforms = []
+        for _ in range(n_layers):
+            transforms.append(
+                MaskedAffineAutoregressiveTransform(
+                    features=self.d_y + self.k,
+                    hidden_features=hidden,
+                    context_features=hidden,
+                )
+            )
+            transforms.append(IdentityTransform())
+        transform = CompositeTransform(transforms)
+        base = StandardNormal([self.d_y + self.k])
+        return Flow(transform, base)
+
+    # ------------------------------------------------------------
+    def _joint_log_prob(
+        self, x: torch.Tensor, y: torch.Tensor, t_onehot: torch.Tensor
+    ) -> torch.Tensor:
+        context = self.cond_net(x)
+        z = torch.cat([y, t_onehot], dim=-1)
+        return self.flow.log_prob(z, context)
+
+    # ------------------------------------------------------------
+    def loss(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        t_obs: torch.Tensor,
+        t_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Negative log-likelihood handling missing treatment labels."""
+
+        y = y.float()
+        t_onehot = nn.functional.one_hot(t_obs.clamp_min(0), num_classes=self.k).float()
+
+        logp_obs = torch.tensor(0.0, device=x.device)
+        if t_mask.any():
+            logp_obs = self._joint_log_prob(
+                x[t_mask == 1], y[t_mask == 1], t_onehot[t_mask == 1]
+            )
+
+        nll = -logp_obs.sum()
+        if (t_mask == 0).any():
+            x_m = x[t_mask == 0]
+            y_m = y[t_mask == 0]
+            all_t = torch.eye(self.k, device=x.device).repeat(len(x_m), 1)
+            rep_x = x_m.repeat_interleave(self.k, dim=0)
+            rep_y = y_m.repeat_interleave(self.k, dim=0)
+            logp_all = self._joint_log_prob(rep_x, rep_y, all_t)
+            logp_miss = torch.logsumexp(logp_all.view(len(x_m), self.k), dim=1)
+            nll += -logp_miss.sum()
+        return nll / x.size(0)
+
+    # ------------------------------------------------------------
+    @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        t_onehot = nn.functional.one_hot(t, num_classes=self.k).float()
+        context = self.cond_net(x)
+        n = 100 if not self.training else 1
+        z = self.flow.sample(n, context)  # (B, n, D+k)
+        context_exp = context.unsqueeze(1).expand(-1, n, -1)
+        z[..., self.d_y :] = t_onehot.unsqueeze(1).expand(-1, n, -1)
+        z_flat = z.reshape(-1, self.d_y + self.k)
+        ctx_flat = context_exp.reshape(-1, context.size(-1))
+        y_flat, _ = self.flow._transform.inverse(z_flat, ctx_flat)
+        y_samples = y_flat[:, : self.d_y].view(x.size(0), n, self.d_y)
+        return y_samples.mean(1)
+
+    # ------------------------------------------------------------
+    @torch.no_grad()
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        y = y.float()
+        all_t = torch.eye(self.k, device=x.device).repeat(len(x), 1)
+        rep_x = x.repeat_interleave(self.k, dim=0)
+        rep_y = y.repeat_interleave(self.k, dim=0)
+        logp = self._joint_log_prob(rep_x, rep_y, all_t)
+        return logp.view(len(x), self.k).softmax(dim=-1)
+
+    # ------------------------------------------------------------
+    @torch.no_grad()
+    def potential_outcome(
+        self, x: torch.Tensor, t_star: int | torch.Tensor, n: int = 100
+    ) -> torch.Tensor:
+        t_star_oh = nn.functional.one_hot(
+            torch.as_tensor(t_star, device=x.device), self.k
+        ).float()
+        context = self.cond_net(x)
+        z = self.flow.sample(n, context)
+        z[..., self.d_y :] = t_star_oh
+        return self.flow._transform.inverse(z, context)[..., : self.d_y]
+
+
+__all__ = ["CNFlowModel"]


### PR DESCRIPTION
## Summary
- implement `CNFlowModel` conditional normalising flow
- expose it in the models package
- depend on `nflows>=0.16`
- basic unit test for shape and gradient
- fix dimension naming and MLP construction

## Testing
- `ruff check . --fix`
- `black xtylearner/models/cnflow_model.py tests/test_cnflow.py xtylearner/models/__init__.py -q`
- `PYTHONPATH=. pytest tests/test_cnflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687033eca3908324994fde1b7efd30e4