### PR TITLE
Improve CaCoRE docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The model registry exposes a variety of architectures grouped below by type.
   pseudo-labels for partially observed treatments.
 - ``DragonNet`` – shared encoder with outcome and propensity heads plus
   targeted regularisation for robust effect estimates.
+- ``CaCoRE`` – a contrastive representation encoder linking ``h(x)`` with the
+  joint outcome-treatment space.
 - ``MaskedTabularTransformer`` – a transformer encoder for tabular data using a
   masked-token training objective.
 


### PR DESCRIPTION
## Summary
- document CaCoRE parameters, loss and prediction helpers
- mention CaCoRE in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870646c5100832483b9266dd3e7539c