### PR TITLE
Implement forward for CNFlowModel

### DIFF
--- a/tests/test_cnflow.py
+++ b/tests/test_cnflow.py
@@ -1,6 +1,9 @@
 import torch
+from torch.utils.data import DataLoader
 
+from xtylearner.data import load_synthetic_dataset
 from xtylearner.models import CNFlowModel
+from xtylearner.training import Trainer
 
 
 def test_shapes():
@@ -21,3 +24,16 @@ def test_shapes():
     probs = model.predict_treatment_proba(x[:3], y[:3])
     assert probs.shape == (3, k)
     assert torch.allclose(probs.sum(-1), torch.ones(3), atol=1e-5)
+
+
+def test_forward_and_trainer():
+    ds = load_synthetic_dataset(n_samples=12, d_x=2, seed=0)
+    X, Y, T = ds.tensors
+    model = CNFlowModel(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    loader = DataLoader(ds, batch_size=4)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+
+    preds = trainer.predict(X, T)
+    assert preds.shape == (12, 1)


### PR DESCRIPTION
## Summary
- provide `forward` method on CNFlowModel for prediction with `Trainer`
- test new forward method via trainer integration

## Testing
- `pytest tests/test_cnflow.py::test_forward_and_trainer -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a04aade483248765e174c86ab3aa