### PR TITLE
Add SemiITE co-training model

### DIFF
--- a/tests/models/test_semiite.py
+++ b/tests/models/test_semiite.py
@@ -1,0 +1,27 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from xtylearner.data import load_synthetic_dataset
+from xtylearner.models import SemiITE
+from xtylearner.training import CoTrainTrainer
+
+
+def test_semiite_shapes_and_trainer():
+    ds = load_synthetic_dataset(n_samples=20, d_x=2, seed=0)
+    X, Y, T = ds.tensors
+    T_obs = T.clone()
+    T_obs[::2] = -1
+
+    model = SemiITE(d_x=2, d_y=1, k=2)
+    rep = model.encode(X)
+    mmd = model.compute_mmd(rep, T)
+    assert mmd.dim() == 0
+    out = model.predict_outcome(X, T)
+    assert out.shape == (20, 1)
+
+    loader = DataLoader(TensorDataset(X, Y, T_obs), batch_size=5)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = CoTrainTrainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -25,6 +25,7 @@ from xtylearner.models import (
     VAT_Model,
     FixMatch,
     SSDMLModel,
+    SemiITE,
     SS_CEVAE,
     CEVAE_M,
     GANITE,
@@ -62,6 +63,7 @@ from xtylearner.models import (
         ("vat", VAT_Model, {"d_x": 2, "d_y": 1, "k": 2}),
         ("fixmatch", FixMatch, {}),
         ("ss_dml", SSDMLModel, {}),
+        ("semiite", SemiITE, {"d_x": 2, "d_y": 1}),
     ],
 )
 def test_get_model_valid(name, cls, kwargs):

--- a/xtylearner/configs/semiite.yaml
+++ b/xtylearner/configs/semiite.yaml
@@ -1,0 +1,3 @@
+lambda_u: 0.5
+q_pseudo: 32
+mmd_beta: 1e-2

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -30,6 +30,7 @@ from .deconfounder_model import DeconfounderCFM
 from .vacim_model import VACIM
 from .factor_vae_plus import FactorVAEPlus
 from .cnflow_model import CNFlowModel
+from .semiite import SemiITE
 from .registry import get_model, get_model_names, get_model_args
 
 __all__ = [
@@ -65,6 +66,7 @@ __all__ = [
     "VACIM",
     "FactorVAEPlus",
     "CNFlowModel",
+    "SemiITE",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/semiite.py
+++ b/xtylearner/models/semiite.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .layers import make_mlp
+from .registry import register_model
+
+
+@register_model("semiite")
+class SemiITE(nn.Module):
+    """Co-training network for semi-supervised treatment effect estimation."""
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int = 1,
+        k: int = 2,
+        *,
+        rep_dim: int = 128,
+        lambda_u: float = 0.5,
+        q_pseudo: int = 32,
+        mmd_beta: float = 1e-2,
+    ) -> None:
+        super().__init__()
+        self.k = k
+        self.lambda_u = lambda_u
+        self.q_pseudo = q_pseudo
+        self.mmd_beta = mmd_beta
+
+        self.enc = make_mlp([d_x, 256, rep_dim])
+        self.prop = nn.Linear(rep_dim, k)
+        self.outcome = nn.ModuleList(
+            [make_mlp([rep_dim + k, 128, d_y]) for _ in range(3)]
+        )
+
+    # --------------------------------------------------------------
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        return self.enc(x)
+
+    # --------------------------------------------------------------
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        z = self.encode(x)
+        t1h = F.one_hot(t.to(torch.long), self.k).float()
+        return self.outcome[0](torch.cat([z, t1h], dim=-1))
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_treatment_proba(self, x: torch.Tensor) -> torch.Tensor:
+        z = self.encode(x)
+        return self.prop(z).softmax(dim=-1)
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: int | torch.Tensor) -> torch.Tensor:
+        z = self.encode(x)
+        if isinstance(t, int):
+            t = torch.full((x.size(0),), t, dtype=torch.long, device=x.device)
+        t1h = F.one_hot(t.to(torch.long), self.k).float()
+        return self.outcome[0](torch.cat([z, t1h], dim=-1))
+
+    # --------------------------------------------------------------
+    def compute_mmd(self, z: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        vals = t.unique()
+        if vals.numel() < 2:
+            return torch.tensor(0.0, device=z.device)
+        means = [z[t == v].mean(0) for v in vals]
+        mmd = 0.0
+        for i in range(len(means)):
+            for j in range(i + 1, len(means)):
+                mmd += (means[i] - means[j]).pow(2).mean()
+        return mmd / (len(means) * (len(means) - 1) / 2)
+
+
+__all__ = ["SemiITE"]

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -7,6 +7,7 @@ from .supervised import SupervisedTrainer
 from .adversarial import AdversarialTrainer
 from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
+from .cotrain import CoTrainTrainer
 from .gnn_trainer import GNNTrainer
 from .em import ArrayTrainer, EMTrainer
 from .metrics import (
@@ -22,6 +23,7 @@ __all__ = [
     "SupervisedTrainer",
     "GenerativeTrainer",
     "DiffusionTrainer",
+    "CoTrainTrainer",
     "GNNTrainer",
     "AdversarialTrainer",
     "ArrayTrainer",

--- a/xtylearner/training/cotrain.py
+++ b/xtylearner/training/cotrain.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+import torch.nn.functional as F
+
+from .base_trainer import BaseTrainer
+
+
+class CoTrainTrainer(BaseTrainer):
+    """Trainer implementing the SemiITE co-training loop."""
+
+    def step(self, batch: Iterable[torch.Tensor]) -> torch.Tensor:
+        x, y, t_obs = self._extract_batch(batch)
+        z = self.model.encode(x)
+        logits = self.model.prop(z)
+        k = self.model.k
+
+        labelled = t_obs >= 0
+        loss = torch.tensor(0.0, device=self.device)
+
+        if labelled.any():
+            t_lab = t_obs[labelled].to(torch.long)
+            t1h_lab = F.one_hot(t_lab, k).float()
+            z_lab = z[labelled]
+            for head in self.model.outcome:
+                pred = head(torch.cat([z_lab, t1h_lab], dim=-1))
+                loss = loss + F.mse_loss(pred, y[labelled])
+            loss = loss + F.cross_entropy(logits[labelled], t_lab)
+            if self.model.mmd_beta > 0:
+                loss = loss + self.model.mmd_beta * self.model.compute_mmd(z_lab, t_lab)
+
+        unlabelled = ~labelled
+        if unlabelled.any() and self.model.lambda_u > 0 and self.model.q_pseudo > 0:
+            z_u = z[unlabelled]
+            logits_u = logits[unlabelled]
+            t_hat = logits_u.argmax(dim=-1)
+            t1h_hat = F.one_hot(t_hat, k).float()
+
+            t0 = F.one_hot(
+                torch.zeros(len(z_u), dtype=torch.long, device=self.device), k
+            ).float()
+            t1 = F.one_hot(
+                torch.ones(len(z_u), dtype=torch.long, device=self.device), k
+            ).float()
+            preds = []
+            disagree = []
+            for head in self.model.outcome:
+                y0 = head(torch.cat([z_u, t0], dim=-1))
+                y1 = head(torch.cat([z_u, t1], dim=-1))
+                preds.append(torch.stack([y0, y1], dim=1))
+                disagree.append((y0 - y1).abs().mean(dim=-1))
+
+            q = min(self.model.q_pseudo, z_u.size(0))
+            if q > 0:
+                unsup = torch.tensor(0.0, device=self.device)
+                for i, head in enumerate(self.model.outcome):
+                    idx = torch.topk(disagree[i], q, largest=False).indices
+                    if idx.numel() == 0:
+                        continue
+                    teacher = (i + 1) % 3
+                    y_teacher = preds[teacher][idx, t_hat[idx]]
+                    y_student = head(torch.cat([z_u[idx], t1h_hat[idx]], dim=-1))
+                    unsup = unsup + F.mse_loss(y_student, y_teacher.detach())
+                loss = loss + self.model.lambda_u * unsup
+
+        return loss
+
+    def fit(self, num_epochs: int) -> None:
+        for epoch in range(num_epochs):
+            self.model.train()
+            num_batches = len(self.train_loader)
+            if self.logger:
+                self.logger.start_epoch(epoch + 1, num_batches)
+            for batch_idx, batch in enumerate(self.train_loader):
+                X, Y, T_obs = self._extract_batch(batch)
+                loss = self.step(batch)
+                self.optimizer.zero_grad()
+                loss.backward()
+                self._clip_grads()
+                self.optimizer.step()
+                if self.logger:
+                    metrics = dict(self._metrics_from_loss(loss))
+                    metrics.update(self._treatment_metrics(X, Y, T_obs))
+                    metrics.update(self._outcome_metrics(X, Y, T_obs))
+                    self.logger.log_step(epoch + 1, batch_idx, num_batches, metrics)
+            if self.scheduler is not None:
+                self.scheduler.step()
+            if self.logger and self.val_loader is not None:
+                val_metrics = self._eval_metrics(self.val_loader)
+                self.logger.log_validation(epoch + 1, val_metrics)
+            if self.logger:
+                self.logger.end_epoch(epoch + 1)
+
+    def evaluate(self, data_loader: Iterable) -> float:
+        metrics = self._eval_metrics(data_loader)
+        return metrics.get("loss", next(iter(metrics.values()), 0.0))
+
+    def predict(self, *inputs: torch.Tensor):
+        self.model.eval()
+        with torch.no_grad():
+            inputs = [i.to(self.device) for i in inputs]
+            if hasattr(self.model, "predict"):
+                return self.model.predict(*inputs)
+            return self.model(*inputs)
+
+
+__all__ = ["CoTrainTrainer"]


### PR DESCRIPTION
## Summary
- implement SemiITE model with encoder, propensity, and three outcome heads
- add CoTrainTrainer implementing the co-training loop
- register the model and trainer
- provide default config
- cover new functionality with tests

## Testing
- `ruff check xtylearner/models/semiite.py xtylearner/training/cotrain.py tests/models/test_semiite.py tests/test_registry.py xtylearner/training/__init__.py xtylearner/models/__init__.py`
- `pytest -k semiite -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bb908db48324b922d94eccd6bfa8