### PR TITLE
Fix rmse logging for BridgeDiff

### DIFF
--- a/xtylearner/models/bridge_diff.py
+++ b/xtylearner/models/bridge_diff.py
@@ -156,7 +156,7 @@ class BridgeDiff(nn.Module):
                 prev = tau - 1 / n_steps
                 noise_scale = (sig**2 - self._sigma(prev).pow(2)).sqrt()
                 noise = torch.randn_like(y[:, 0])
-                y = y + noise_scale * noise.unsqueeze(1)
+                y = y + noise_scale.unsqueeze(-1) * noise.unsqueeze(1)
         return tuple(y[:, t] for t in range(self.k))
 
     # ----- posterior utility -----


### PR DESCRIPTION
## Summary
- fix noise broadcasting in `BridgeDiff.paired_sample`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879de7517d08324b48f3e86bb8e5bf8