### PR TITLE
Add registry-wide argument test

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -110,3 +110,10 @@ def test_get_model_args_valid():
 def test_get_model_args_invalid():
     with pytest.raises(ValueError):
         get_model_args("unknown_model")
+
+
+def test_all_models_accept_standard_args():
+    """Every registered model should accept d_x, d_y and k."""
+    for name in get_model_names():
+        model = get_model(name, d_x=1, d_y=1, k=2)
+        assert model is not None

--- a/xtylearner/models/ctm_t.py
+++ b/xtylearner/models/ctm_t.py
@@ -11,7 +11,22 @@ from .utils import sinusoidal_time_embed, UNet1D
 class CTMT(nn.Module):
     """Consistency-Trajectory Model with a treatment head."""
 
-    def __init__(self, d_in: int, d_treat: int = 2, hidden: int = 64) -> None:
+    def __init__(
+        self,
+        d_in: int | None = None,
+        d_treat: int = 2,
+        hidden: int = 64,
+        *,
+        d_x: int | None = None,
+        d_y: int | None = None,
+        k: int | None = None,
+    ) -> None:
+        if d_in is None and d_x is None:
+            raise TypeError("d_in or d_x must be specified")
+        if d_x is not None:
+            d_in = d_x
+        if k is not None:
+            d_treat = k
         super().__init__()
         self.d_in = d_in
         self.d_treat = d_treat

--- a/xtylearner/models/deconfounder_model.py
+++ b/xtylearner/models/deconfounder_model.py
@@ -31,12 +31,18 @@ class DeconfounderCFM(nn.Module):
         self,
         d_x: int,
         d_y: int,
-        k_t: int,
+        k_t: int | None = None,
         d_z: int = 16,
         hidden: int = 64,
         pretrain_epochs: int = 50,
         ppc_freq: int = 25,
+        *,
+        k: int | None = None,
     ) -> None:
+        if k_t is None:
+            k_t = k
+        elif k is not None:
+            k_t = k
         super().__init__()
         self.vae_t = VAE_T(k_t, d_z, hidden)
         self.out_net = OutcomeNet(d_x + d_z + k_t, d_y, hidden)

--- a/xtylearner/models/em_model.py
+++ b/xtylearner/models/em_model.py
@@ -169,6 +169,8 @@ class EMModel:
         classifier_factory=None,
         regressor_factory=None,
         verbose: bool = False,
+        d_x: int | None = None,
+        d_y: int | None = None,
     ) -> None:
         self.k = k
         self.max_iter = max_iter

--- a/xtylearner/models/ganite.py
+++ b/xtylearner/models/ganite.py
@@ -24,11 +24,14 @@ class GANITE(nn.Module):
         d_x: int,
         d_y: int = 1,
         *,
+        k: int | None = None,
         hidden_dims: tuple[int, ...] | list[int] = (200, 200),
         activation: type[nn.Module] = nn.ReLU,
         dropout: float | None = None,
         norm_layer: Callable[[int], nn.Module] | None = None,
     ) -> None:
+        if k is not None:
+            self.k = k
         super().__init__()
         self.G_cf = make_mlp(
             [d_x + d_y + self.k, *hidden_dims, d_y],

--- a/xtylearner/models/gnn_ebm.py
+++ b/xtylearner/models/gnn_ebm.py
@@ -52,15 +52,20 @@ class GNN_EBM(nn.Module):
     def __init__(
         self,
         d_x: int,
-        k_t: int,
         d_y: int,
+        k_t: int | None = None,
         *,
+        k: int | None = None,
         hidden: int = 128,
         k_langevin: int = 20,
         eta: float = 1e-2,
         lambda_acyc: float = 5.0,
         gamma_l1: float = 1e-2,
     ) -> None:
+        if k_t is None:
+            k_t = k
+        elif k is not None:
+            k_t = k
         super().__init__()
         self.d_x = d_x
         self.k_t = k_t

--- a/xtylearner/models/labelprop.py
+++ b/xtylearner/models/labelprop.py
@@ -34,10 +34,18 @@ class LP_KNN:
     target = "treatment"
     requires_outcome = False
 
-    def __init__(self, n_neighbors: int = 10, regressor=None):
+    def __init__(
+        self,
+        n_neighbors: int = 10,
+        regressor=None,
+        *,
+        d_x: int | None = None,
+        d_y: int | None = None,
+        k: int | None = None,
+    ):
         self.clf = LabelPropagation(kernel="knn", n_neighbors=n_neighbors)
         self.regressor = regressor
-        self.k = None
+        self.k = k
 
     # ------------------------------------------------------------------
     def fit(self, X, y, t_obs=None):

--- a/xtylearner/models/prob_circuit_model.py
+++ b/xtylearner/models/prob_circuit_model.py
@@ -48,7 +48,14 @@ from .registry import register_model
 class ProbCircuitModel:
     """Learn a probabilistic circuit over ``(X, T, Y)`` using SPFlow."""
 
-    def __init__(self, min_instances_slice: int = 200) -> None:
+    def __init__(
+        self,
+        min_instances_slice: int = 200,
+        *,
+        d_x: int | None = None,
+        d_y: int | None = None,
+        k: int | None = None,
+    ) -> None:
         self.min_instances_slice = min_instances_slice
         self.root = None
         self._lr = None

--- a/xtylearner/models/ss_dml.py
+++ b/xtylearner/models/ss_dml.py
@@ -26,6 +26,10 @@ class SSDMLModel:
         ml_pi=None,
         n_folds: int = 5,
         score: str = "missing-at-random",
+        *,
+        d_x: int | None = None,
+        d_y: int | None = None,
+        k: int | None = None,
     ):
         self.ml_g = ml_g or RandomForestRegressor(min_samples_leaf=5)
         self.ml_m = ml_m or RandomForestClassifier()


### PR DESCRIPTION
## Summary
- add new test that ensures all registered models can be created with `d_x`, `d_y` and `k`
- update various model constructors so they accept `d_x`, `d_y` and `k` kwargs

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fb533a748324b6761fa3a8378554