### PR TITLE
Add noise and logger tests

### DIFF
--- a/tests/test_logger_noise.py
+++ b/tests/test_logger_noise.py
@@ -1,0 +1,42 @@
+import torch
+import pytest
+
+from xtylearner.noise_schedules import add_noise
+from xtylearner.training.logger import ConsoleLogger
+
+
+def test_add_noise_deterministic():
+    x = torch.zeros(2, 3)
+    scale = torch.tensor(0.5)
+    torch.manual_seed(0)
+    expected = torch.randn_like(x) * scale + x
+    torch.manual_seed(0)
+    out = add_noise(x, scale)
+    assert torch.allclose(out, expected)
+
+
+def test_add_noise_vector_scale():
+    x = torch.zeros(2, 2)
+    scale = torch.tensor([0.0, 1.0])
+    torch.manual_seed(1)
+    noise = torch.randn_like(x)
+    expected = x + noise * scale.unsqueeze(-1)
+    torch.manual_seed(1)
+    out = add_noise(x, scale)
+    assert torch.allclose(out, expected)
+
+
+def test_console_logger_outputs_and_averages(capsys):
+    logger = ConsoleLogger(print_every=2)
+    logger.start_epoch(1, 3)
+    logger.log_step(1, 0, 3, {"loss": 1.0})
+    logger.log_step(1, 1, 3, {"loss": 2.0})
+    logger.log_step(1, 2, 3, {"loss": 3.0})
+    logger.log_validation(1, {"val": 0.5})
+    logger.end_epoch(1)
+    out = capsys.readouterr().out
+    assert "Epoch 1 [2/3]" in out
+    assert "Epoch 1 [3/3]" in out
+    assert "Epoch 1 validation: val=0.5000" in out
+    assert "Epoch 1 finished:" in out
+    assert logger.averages()["loss"] == pytest.approx(2.0)

--- a/xtylearner/models/vime.py
+++ b/xtylearner/models/vime.py
@@ -122,6 +122,14 @@ class VIME(nn.Module):
         return logits.softmax(dim=-1).cpu()
 
     # --------------------------------------------------------------
+    def predict_treatment_proba(
+        self, x: torch.Tensor, _y: torch.Tensor
+    ) -> torch.Tensor:
+        """Alias of :meth:`predict_proba` for API compatibility."""
+
+        return self.predict_proba(x)
+
+    # --------------------------------------------------------------
     def predict(self, X: torch.Tensor | list) -> torch.Tensor:
         return self.predict_proba(X).argmax(dim=1)
 


### PR DESCRIPTION
## Summary
- test noise_schedule's `add_noise`
- test basic functionality of `ConsoleLogger`
- implement `predict_treatment_proba` in `VIME` for registry tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b6ca2b7608324a5badb3d8518a2b4