### PR TITLE
Implement active learning components

### DIFF
--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -1,0 +1,29 @@
+import torch
+from xtylearner.models import MultiTask
+from xtylearner.active import EntropyT, DeltaCATE, FCCMRadius
+
+
+def test_entropy_strategy_runs():
+    model = MultiTask(d_x=2, d_y=1, k=2)
+    X = torch.randn(4, 2)
+    strat = EntropyT()
+    scores = strat(model, X, getattr(model, "h", None), 2)
+    assert scores.shape == (4,)
+
+
+def test_var_strategy_runs():
+    model = MultiTask(d_x=2, d_y=1, k=2)
+    X = torch.randn(3, 2)
+    strat = DeltaCATE()
+    scores = strat(model, X, getattr(model, "h", None), 2)
+    assert scores.shape == (3,)
+
+
+def test_fccm_strategy_combines():
+    model = MultiTask(d_x=2, d_y=1, k=2)
+    X_lab = torch.randn(2, 2)
+    X_unlab = torch.randn(5, 2)
+    strat = FCCMRadius()
+    strat.update_labeled(X_lab)
+    scores = strat(model, X_unlab, getattr(model, "h", None), 2)
+    assert scores.shape == (5,)

--- a/xtylearner/active/__init__.py
+++ b/xtylearner/active/__init__.py
@@ -1,0 +1,11 @@
+"""Active learning utilities and query strategies."""
+
+from .strategies import QueryStrategy, EntropyT, DeltaCATE, FCCMRadius, STRATEGIES
+
+__all__ = [
+    "QueryStrategy",
+    "EntropyT",
+    "DeltaCATE",
+    "FCCMRadius",
+    "STRATEGIES",
+]

--- a/xtylearner/active/strategies.py
+++ b/xtylearner/active/strategies.py
@@ -1,0 +1,135 @@
+import torch
+import torch.nn as nn
+from typing import Callable, Tuple
+
+
+class QueryStrategy(nn.Module):
+    """Base class for active learning query strategies."""
+
+    def forward(
+        self,
+        model: nn.Module,
+        X_unlab: torch.Tensor,
+        rep_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+        batch_size: int,
+    ) -> torch.Tensor:
+        """Return acquisition scores for ``X_unlab``."""
+        raise NotImplementedError
+
+
+class EntropyT(QueryStrategy):
+    """Query points with high treatment entropy."""
+
+    @staticmethod
+    def _treatment_proba(model: nn.Module, x: torch.Tensor) -> torch.Tensor:
+        if hasattr(model, "predict_treatment_proba"):
+            try:
+                return model.predict_treatment_proba(x)
+            except Exception:
+                pass
+
+        def _call(head, inp):
+            try:
+                return head(inp)
+            except Exception:
+                d_y = getattr(model, "d_y", 1)
+                zeros = torch.zeros(len(inp), d_y, device=inp.device)
+                return head(torch.cat([inp, zeros], dim=-1))
+
+        if hasattr(model, "cls_t"):
+            logits = _call(model.cls_t, x)
+        elif hasattr(model, "head_T"):
+            logits = _call(model.head_T, x)
+        elif hasattr(model, "C"):
+            logits = _call(model.C, x)
+        else:
+            raise ValueError("Model does not expose treatment head")
+
+        return logits.softmax(dim=-1)
+
+    def forward(
+        self,
+        model: nn.Module,
+        X_unlab: torch.Tensor,
+        rep_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+        batch_size: int,
+    ) -> torch.Tensor:
+        with torch.no_grad():
+            probs = self._treatment_proba(model, X_unlab)
+            log_p = probs.clamp_min(1e-12).log()
+            return -(probs * log_p).sum(dim=-1)
+
+
+class DeltaCATE(QueryStrategy):
+    """Query points with uncertain treatment effect."""
+
+    def _predict_outcome(
+        self, model: nn.Module, x: torch.Tensor, t: torch.Tensor
+    ) -> torch.Tensor:
+        if hasattr(model, "predict_outcome"):
+            return model.predict_outcome(x, int(t[0].item()) if t.numel() == 1 else t)
+        k = getattr(model, "k", 2)
+        t1h = torch.nn.functional.one_hot(t.to(torch.long), k).float()
+        if hasattr(model, "head_Y"):
+            if hasattr(model, "h"):
+                h = model.h(x)
+                return model.head_Y(torch.cat([h, t1h], dim=-1))
+            return model.head_Y(torch.cat([x, t1h], dim=-1))
+        return model(x, t)
+
+    def forward(
+        self,
+        model: nn.Module,
+        X_unlab: torch.Tensor,
+        rep_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+        batch_size: int,
+    ) -> torch.Tensor:
+        k = getattr(model, "k", 2)
+        with torch.no_grad():
+            preds = []
+            for t_val in range(k):
+                t = torch.full((len(X_unlab),), t_val, device=X_unlab.device)
+                preds.append(self._predict_outcome(model, X_unlab, t).unsqueeze(1))
+            pred = torch.cat(preds, dim=1)
+            var = pred.var(dim=1)
+            return var.mean(dim=-1)
+
+
+class FCCMRadius(QueryStrategy):
+    """Weighted combination of entropy, variance and coverage radius."""
+
+    def __init__(self, lambdas: Tuple[float, float, float] = (0.5, 0.3, 0.2)) -> None:
+        super().__init__()
+        self.lambdas = lambdas
+        self._X_lab: torch.Tensor | None = None
+
+    def update_labeled(self, X_lab: torch.Tensor) -> None:
+        self._X_lab = X_lab
+
+    def _radius(self, rep_u: torch.Tensor, rep_l: torch.Tensor) -> torch.Tensor:
+        dists = torch.cdist(rep_u, rep_l)
+        return dists.min(dim=1).values
+
+    def forward(
+        self,
+        model: nn.Module,
+        X_unlab: torch.Tensor,
+        rep_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+        batch_size: int,
+    ) -> torch.Tensor:
+        rep = rep_fn if rep_fn is not None else (lambda x: x)
+        entropy = EntropyT()(model, X_unlab, rep_fn, batch_size)
+        var = DeltaCATE()(model, X_unlab, rep_fn, batch_size)
+        if self._X_lab is None:
+            radius = torch.zeros_like(entropy)
+        else:
+            rep_u = rep(X_unlab)
+            rep_l = rep(self._X_lab)
+            radius = self._radius(rep_u, rep_l)
+        l1, l2, l3 = self.lambdas
+        return l1 * entropy + l2 * var + l3 * radius
+
+
+STRATEGIES = {"entropy": EntropyT, "var": DeltaCATE, "fccm": FCCMRadius}
+
+__all__ = ["QueryStrategy", "EntropyT", "DeltaCATE", "FCCMRadius", "STRATEGIES"]

--- a/xtylearner/configs/active.yaml
+++ b/xtylearner/configs/active.yaml
@@ -1,0 +1,4 @@
+strategy: fccm
+budget: 500
+batch: 20
+lambdas: [0.5, 0.3, 0.2]

--- a/xtylearner/training/__init__.py
+++ b/xtylearner/training/__init__.py
@@ -9,6 +9,7 @@ from .generative import GenerativeTrainer
 from .diffusion import DiffusionTrainer
 from .ctm_trainer import CTMTrainer
 from .cotrain import CoTrainTrainer
+from .active_trainer import ActiveTrainer
 from .gnn_trainer import GNNTrainer
 from .em import ArrayTrainer, EMTrainer
 from .metrics import (
@@ -28,6 +29,7 @@ __all__ = [
     "CoTrainTrainer",
     "GNNTrainer",
     "AdversarialTrainer",
+    "ActiveTrainer",
     "ArrayTrainer",
     "EMTrainer",
     "Trainer",

--- a/xtylearner/training/active_trainer.py
+++ b/xtylearner/training/active_trainer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from .supervised import SupervisedTrainer
+from .logger import TrainerLogger
+from ..active import QueryStrategy
+
+
+class ActiveTrainer(SupervisedTrainer):
+    """Simple active learning loop over a semi-supervised dataset."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        train_loader: Iterable,
+        strategy: QueryStrategy,
+        budget: int,
+        batch: int,
+        val_loader: Optional[Iterable] = None,
+        device: str = "cpu",
+        logger: Optional["TrainerLogger"] = None,
+        scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
+        grad_clip_norm: float | None = None,
+    ) -> None:
+        super().__init__(
+            model,
+            optimizer,
+            train_loader,
+            val_loader,
+            device,
+            logger,
+            scheduler,
+            grad_clip_norm,
+        )
+        self.strategy = strategy
+        self.budget = budget
+        self.batch = batch
+        self.queries = 0
+
+    # --------------------------------------------------------------
+    def _budget_left(self) -> bool:
+        return self.queries < self.budget
+
+    # --------------------------------------------------------------
+    def fit(self, num_epochs: int) -> None:
+        dataset = self.train_loader.dataset  # type: ignore[attr-defined]
+        if not hasattr(dataset, "tensors"):
+            raise ValueError("ActiveTrainer requires a TensorDataset")
+        X, Y, T = dataset.tensors
+        labelled = T >= 0
+        L = TensorDataset(X[labelled], Y[labelled], T[labelled])
+        U = TensorDataset(X[~labelled], Y[~labelled], T[~labelled])
+
+        while self._budget_left() and len(U) > 0:
+            loader_L = DataLoader(
+                L, batch_size=self.train_loader.batch_size, shuffle=True
+            )
+            self.train_loader = loader_L
+            super().fit(num_epochs)
+
+            if hasattr(self.strategy, "update_labeled"):
+                self.strategy.update_labeled(L.tensors[0])
+
+            rep_fn = getattr(self.model, "encoder", None)
+            scores = self.strategy(self.model, U.tensors[0], rep_fn, self.batch)
+            topk = torch.topk(scores, min(self.batch, len(U)), largest=True).indices
+
+            new_X = U.tensors[0][topk]
+            new_Y = U.tensors[1][topk]
+            new_T = U.tensors[2][topk]
+            L = TensorDataset(
+                torch.cat([L.tensors[0], new_X]),
+                torch.cat([L.tensors[1], new_Y]),
+                torch.cat([L.tensors[2], new_T]),
+            )
+            mask = torch.ones(len(U), dtype=torch.bool)
+            mask[topk] = False
+            U = TensorDataset(
+                U.tensors[0][mask],
+                U.tensors[1][mask],
+                U.tensors[2][mask],
+            )
+            self.queries += len(topk)
+
+        self.train_loader = DataLoader(
+            L, batch_size=self.train_loader.batch_size, shuffle=True
+        )
+        super().fit(num_epochs)


### PR DESCRIPTION
## Summary
- add query strategies for active learning
- implement an ActiveTrainer with a basic labelling loop
- expose ActiveTrainer via training package
- provide an example configuration
- test entropy/variance/FCCM strategies

## Testing
- `pre-commit run --files xtylearner/active/strategies.py tests/test_active.py xtylearner/training/active_trainer.py xtylearner/training/__init__.py xtylearner/active/__init__.py xtylearner/configs/active.yaml`
- `pytest -q tests/test_active.py`

------
https://chatgpt.com/codex/tasks/task_e_687c25debb888324b1c94bb3a7b8e3c2