### PR TITLE
Add ActiveTrainer registry test

### DIFF
--- a/tests/test_active_trainer_registry.py
+++ b/tests/test_active_trainer_registry.py
@@ -1,0 +1,61 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from xtylearner.data import load_mixed_synthetic_dataset
+from xtylearner.models import get_model, get_model_names
+from xtylearner.models.ss_dml import _HAS_DOUBLEML
+from xtylearner.training import ActiveTrainer
+from xtylearner.active import QueryStrategy
+
+
+class DummyStrategy(QueryStrategy):
+    def forward(self, model, X_unlab, rep_fn, batch_size):
+        return torch.zeros(len(X_unlab))
+
+
+def _make_optimizer(model: torch.nn.Module):
+    params = [p for p in getattr(model, "parameters", lambda: [])() if p.requires_grad]
+    if not params:
+        params = [torch.zeros(1, requires_grad=True)]
+    return torch.optim.Adam(params, lr=0.001)
+
+
+def _make_gan_optimizer(model: torch.nn.Module):
+    opt_g = torch.optim.Adam(model.parameters(), lr=0.001)
+    opt_d = torch.optim.Adam(model.parameters(), lr=0.001)
+    return opt_g, opt_d
+
+
+def test_active_trainer_runs_for_all_models():
+    ds = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=0, label_ratio=0.5)
+    X, Y, T = ds.tensors
+    base_loader = DataLoader(ds, batch_size=4)
+
+    for name in get_model_names():
+        if name == "ss_dml" and not _HAS_DOUBLEML:
+            continue
+
+        kwargs = {"d_x": 2, "d_y": 1, "k": 2}
+        if name == "lp_knn":
+            kwargs["n_neighbors"] = 3
+        if name == "ctm_t":
+            kwargs = {"d_in": 4}
+
+        model = get_model(name, **kwargs)
+
+        if name == "deconfounder_cfm":
+            t = torch.nn.functional.one_hot(T.clamp_min(0), 2).float()
+            t[T < 0] = float("nan")
+            loader = DataLoader(TensorDataset(X, Y, t), batch_size=4)
+        else:
+            loader = base_loader
+
+        if hasattr(model, "loss_G") and hasattr(model, "loss_D"):
+            opt = _make_gan_optimizer(model)
+        else:
+            opt = _make_optimizer(model)
+
+        trainer = ActiveTrainer(model, opt, loader, DummyStrategy(), budget=2, batch=1)
+        trainer.fit(1)
+
+

--- a/xtylearner/training/active_trainer.py
+++ b/xtylearner/training/active_trainer.py
@@ -5,12 +5,12 @@ from typing import Iterable, Optional
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
-from .supervised import SupervisedTrainer
+from .trainer import Trainer
 from .logger import TrainerLogger
 from ..active import QueryStrategy
 
 
-class ActiveTrainer(SupervisedTrainer):
+class ActiveTrainer:
     """Simple active learning loop over a semi-supervised dataset."""
 
     def __init__(
@@ -27,7 +27,7 @@ class ActiveTrainer(SupervisedTrainer):
         scheduler: Optional[torch.optim.lr_scheduler._LRScheduler] = None,
         grad_clip_norm: float | None = None,
     ) -> None:
-        super().__init__(
+        self._trainer = Trainer(
             model,
             optimizer,
             train_loader,
@@ -48,26 +48,29 @@ class ActiveTrainer(SupervisedTrainer):
 
     # --------------------------------------------------------------
     def fit(self, num_epochs: int) -> None:
-        dataset = self.train_loader.dataset  # type: ignore[attr-defined]
+        dataset = self._trainer.train_loader.dataset  # type: ignore[attr-defined]
         if not hasattr(dataset, "tensors"):
             raise ValueError("ActiveTrainer requires a TensorDataset")
         X, Y, T = dataset.tensors
-        labelled = T >= 0
+        if T.dim() == 1:
+            labelled = T >= 0
+        else:
+            labelled = torch.isfinite(T).all(-1)
         L = TensorDataset(X[labelled], Y[labelled], T[labelled])
         U = TensorDataset(X[~labelled], Y[~labelled], T[~labelled])
 
         while self._budget_left() and len(U) > 0:
             loader_L = DataLoader(
-                L, batch_size=self.train_loader.batch_size, shuffle=True
+                L, batch_size=self._trainer.train_loader.batch_size, shuffle=True
             )
-            self.train_loader = loader_L
-            super().fit(num_epochs)
+            self._trainer.train_loader = loader_L
+            self._trainer.fit(num_epochs)
 
             if hasattr(self.strategy, "update_labeled"):
                 self.strategy.update_labeled(L.tensors[0])
 
-            rep_fn = getattr(self.model, "encoder", None)
-            scores = self.strategy(self.model, U.tensors[0], rep_fn, self.batch)
+            rep_fn = getattr(self._trainer.model, "encoder", None)
+            scores = self.strategy(self._trainer.model, U.tensors[0], rep_fn, self.batch)
             topk = torch.topk(scores, min(self.batch, len(U)), largest=True).indices
 
             new_X = U.tensors[0][topk]
@@ -87,7 +90,27 @@ class ActiveTrainer(SupervisedTrainer):
             )
             self.queries += len(topk)
 
-        self.train_loader = DataLoader(
-            L, batch_size=self.train_loader.batch_size, shuffle=True
+        self._trainer.train_loader = DataLoader(
+            L, batch_size=self._trainer.train_loader.batch_size, shuffle=True
         )
-        super().fit(num_epochs)
+        self._trainer.fit(num_epochs)
+
+    # --------------------------------------------------------------
+    def evaluate(self, data_loader: Iterable) -> float:
+        return self._trainer.evaluate(data_loader)
+
+    # --------------------------------------------------------------
+    def predict(self, *args, **kwargs):
+        return self._trainer.predict(*args, **kwargs)
+
+    # --------------------------------------------------------------
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return self._trainer.predict_treatment_proba(x, y)
+
+    # --------------------------------------------------------------
+    def __getattr__(self, name):
+        return getattr(self._trainer, name)
+
+
+__all__ = ["ActiveTrainer"]
+


### PR DESCRIPTION
## Summary
- support all model types in `ActiveTrainer`
- ensure ActiveTrainer runs on every registered model
- switch registry test to Adam optimiser to avoid NaNs

## Testing
- `pytest tests/test_active_trainer_registry.py::test_active_trainer_runs_for_all_models -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c2cccd0a083248d10e5a8401132df