### PR TITLE
Add CCL-CPC contrastive model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,16 @@
 
 The high level `Trainer` class in `xtylearner/training` automatically picks the
 appropriate trainer based on the presence of these methods.
+
+## ccl_cpc
+
+Identifier: `ccl_cpc`
+
+Hyper-parameters:
+- `hidden` – encoder width (default 128)
+- `lambda_cpc` – weight for the CPC objective
+- `lambda_y` – labelled outcome loss weight
+- `lambda_t` – labelled treatment loss weight
+- `temperature` – InfoNCE softmax temperature
+- `k_future` – prediction horizon in steps
+- `seq_len` – input sequence length

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -31,6 +31,7 @@ from xtylearner.models import (
     GANITE,
     CTMT,
     SCGM,
+    CCL_CPCModel,
 )
 
 
@@ -68,6 +69,7 @@ from xtylearner.models import (
         ("semiite", SemiITE, {"d_x": 2, "d_y": 1}),
         ("ctm_t", CTMT, {"d_in": 4}),
         ("scgm", SCGM, {"d_x": 2, "d_y": 1, "k": 2}),
+        ("ccl_cpc", CCL_CPCModel, {"d_x": 2, "d_y": 1, "k": 2}),
     ],
 )
 def test_get_model_valid(name, cls, kwargs):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -15,6 +15,7 @@ from xtylearner.models import BridgeDiff, LTFlowDiff
 from xtylearner.models import EnergyDiffusionImputer, JointEBM, GFlowNetTreatment
 from xtylearner.models import GANITE
 from xtylearner.models import ProbCircuitModel, LP_KNN, CTMT
+from xtylearner.models import CCL_CPCModel
 
 
 def test_supervised_trainer_runs():
@@ -345,6 +346,19 @@ def test_ctm_trainer_runs():
     d_in = 2 + 1 + 1
     model = CTMT(d_in=d_in)
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+    loss = trainer.evaluate(loader)
+    assert isinstance(loss, float)
+
+
+def test_ccl_cpc_trainer_runs():
+    dataset = load_mixed_synthetic_dataset(
+        n_samples=20, d_x=2, seed=20, label_ratio=0.5
+    )
+    loader = DataLoader(dataset, batch_size=5)
+    model = CCL_CPCModel(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     loss = trainer.evaluate(loader)

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -13,6 +13,7 @@ from .bridge_diff import BridgeDiff
 from .lt_flow_diff import LTFlowDiff
 from .prob_circuit_model import ProbCircuitModel
 from .masked_tabular_transformer import MaskedTabularTransformer
+from .ccl_cpc_model import CCL_CPCModel
 from .gflownet_treatment import GFlowNetTreatment
 from .dragon_net import DragonNet
 from .cacore_model import CaCoRE
@@ -50,6 +51,7 @@ __all__ = [
     "JointEBM",
     "GNN_EBM",
     "MaskedTabularTransformer",
+    "CCL_CPCModel",
     "DragonNet",
     "CaCoRE",
     "ProbCircuitModel",

--- a/xtylearner/models/ccl_cpc_model.py
+++ b/xtylearner/models/ccl_cpc_model.py
@@ -1,0 +1,75 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+from .registry import register_model
+@register_model("ccl_cpc")
+class CCL_CPCModel(nn.Module):
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k: int,
+        hidden: int = 128,
+        lambda_cpc: float = 1.0,
+        lambda_y: float = 1.0,
+        lambda_t: float = 0.1,
+        temperature: float = 0.07,
+        k_future: int = 3,
+        seq_len: int = 1,
+    ) -> None:
+        super().__init__()
+        self.k = k
+        self.d_y = d_y
+        self.tau = temperature
+        self.k_future = k_future
+        self.w = {"cpc": lambda_cpc, "y": lambda_y, "t": lambda_t}
+        self.enc = nn.Sequential(nn.Linear(d_x, hidden), nn.ReLU(), nn.Linear(hidden, hidden))
+        self.rnn = None if seq_len == 1 else nn.GRU(hidden, hidden, batch_first=True)
+        self.out_head = nn.Sequential(nn.Linear(hidden + k, hidden), nn.ReLU(), nn.Linear(hidden, 2 * d_y))
+        self.t_head = nn.Sequential(nn.Linear(hidden + d_y, hidden), nn.ReLU(), nn.Linear(hidden, k))
+    def _encode(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if x.dim() == 2:
+            z = self.enc(x).unsqueeze(1)
+        else:
+            b, l, d = x.shape
+            z = self.enc(x.view(-1, d)).view(b, l, -1)
+        if self.rnn:
+            z, _ = self.rnn(z)
+        return z, z[:, -1]
+    def _info_nce(self, z: torch.Tensor) -> torch.Tensor:
+        a, p, h = z[:, :-self.k_future], z[:, self.k_future:], z.size(-1)
+        sim = a.reshape(-1, h) @ p.reshape(-1, h).T / self.tau
+        return F.cross_entropy(sim, torch.arange(sim.size(0), device=z.device))
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        _, z = self._encode(x)
+        oh = F.one_hot(t.to(torch.long), self.k).float()
+        mu, _ = self.out_head(torch.cat([z, oh], -1)).chunk(2, -1)
+        return mu
+    def loss(self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor) -> torch.Tensor:
+        seq, z = self._encode(x)
+        lcpc = self._info_nce(seq) if seq.size(1) > self.k_future else 0.0
+        t1h = F.one_hot(t_obs.clamp_min(0), self.k).float()
+        mu, log_s = self.out_head(torch.cat([z, t1h], -1)).chunk(2, -1)
+        lab = t_obs >= 0
+        ly = (0.5 * ((y - mu) / log_s.exp()).pow(2) + log_s).sum(-1)
+        ly = (ly * lab).mean()
+        lt = torch.tensor(0.0, device=x.device)
+        if lab.any():
+            logits = self.t_head(torch.cat([z[lab], y[lab]], -1))
+            lt = F.cross_entropy(logits, t_obs[lab])
+        return self.w["cpc"] * lcpc + self.w["y"] * ly + self.w["t"] * lt
+    @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        return self.forward(x, t)
+    @torch.no_grad()
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        _, z = self._encode(x)
+        return self.t_head(torch.cat([z, y], -1)).softmax(-1)
+    @torch.no_grad()
+    def counterfactual(self, x: torch.Tensor) -> torch.Tensor:
+        _, z = self._encode(x)
+        eye = torch.eye(self.k, device=x.device)
+        z = z.unsqueeze(1).expand(-1, self.k, -1)
+        mu, _ = self.out_head(torch.cat([z, eye.expand(z.size(0), -1, -1)], -1)).chunk(2, -1)
+        return mu
+__all__ = ["CCL_CPCModel"]


### PR DESCRIPTION
## Summary
- implement CCL_CPCModel providing contrastive predictive coding
- register `ccl_cpc` model and export from package
- document model identifier and hyper-parameters in AGENTS
- extend registry and trainer tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c438db97c8324b5fbd1a5453b1791