### PR TITLE
Return metrics dict from trainer evaluate

### DIFF
--- a/tests/models/test_scgm.py
+++ b/tests/models/test_scgm.py
@@ -29,5 +29,5 @@ def test_scgm_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}

--- a/tests/models/test_semiite.py
+++ b/tests/models/test_semiite.py
@@ -23,5 +23,5 @@ def test_semiite_shapes_and_trainer():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = CoTrainTrainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}

--- a/tests/test_em_trainer.py
+++ b/tests/test_em_trainer.py
@@ -13,5 +13,5 @@ def test_em_trainer_runs():
     opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}

--- a/tests/test_masked_tabular_transformer.py
+++ b/tests/test_masked_tabular_transformer.py
@@ -16,8 +16,8 @@ def test_masked_tabular_transformer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=1e-3)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
     x_row = X[0]
     y0 = model.predict_y(x_row, t_prompt=0, n_samples=2)

--- a/tests/test_metrics_and_utils.py
+++ b/tests/test_metrics_and_utils.py
@@ -1,6 +1,7 @@
 import math
 import torch
 import pytest
+from typing import Mapping
 
 from xtylearner.training.metrics import (
     mse_loss,
@@ -29,8 +30,8 @@ class DummyTrainer(BaseTrainer):
     def fit(self, num_epochs: int) -> None:
         pass
 
-    def evaluate(self, data_loader) -> float:
-        return 0.0
+    def evaluate(self, data_loader) -> Mapping[str, float]:
+        return {"loss": 0.0, "treatment accuracy": 0.0, "outcome rmse": 0.0}
 
     def predict(self, *args, **kwargs):
         pass

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -25,8 +25,8 @@ def test_supervised_trainer_runs():
     opt = torch.optim.SGD(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_flow_model_runs():
@@ -36,8 +36,8 @@ def test_flow_model_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_multitask_model_runs():
@@ -47,8 +47,8 @@ def test_multitask_model_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_multitask_handles_missing_labels():
@@ -60,8 +60,8 @@ def test_multitask_handles_missing_labels():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_dragon_net_runs():
@@ -71,8 +71,8 @@ def test_dragon_net_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_dragon_net_multi_outcome():
@@ -92,8 +92,8 @@ def test_dragon_net_multi_outcome():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_m2vae_trainer_runs():
@@ -103,8 +103,8 @@ def test_m2vae_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_cevae_trainer_runs():
@@ -114,8 +114,8 @@ def test_cevae_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_supervised_trainer_mixed_dataset():
@@ -125,8 +125,8 @@ def test_supervised_trainer_mixed_dataset():
     opt = torch.optim.SGD(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_cevae_trainer_mixed_dataset():
@@ -136,8 +136,8 @@ def test_cevae_trainer_mixed_dataset():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_jsbf_trainer_runs():
@@ -147,8 +147,8 @@ def test_jsbf_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_diffusion_cevae_trainer_runs():
@@ -158,8 +158,8 @@ def test_diffusion_cevae_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_bridge_diff_trainer_runs():
@@ -169,8 +169,8 @@ def test_bridge_diff_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_lt_flow_diff_trainer_runs():
@@ -182,8 +182,8 @@ def test_lt_flow_diff_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_eg_ddi_trainer_runs():
@@ -195,8 +195,8 @@ def test_eg_ddi_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_joint_ebm_trainer_runs():
@@ -208,8 +208,8 @@ def test_joint_ebm_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_gflownet_treatment_trainer_runs():
@@ -221,8 +221,8 @@ def test_gflownet_treatment_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_ganite_trainer_runs():
@@ -235,8 +235,8 @@ def test_ganite_trainer_runs():
     opt_d = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, (opt_g, opt_d), loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 def test_ganite_with_schedulers():
     dataset = load_mixed_synthetic_dataset(
@@ -334,8 +334,8 @@ def test_labelprop_trainer_runs():
     opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    acc = trainer.evaluate(loader)
-    assert isinstance(acc, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_ctm_trainer_runs():
@@ -348,8 +348,8 @@ def test_ctm_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.001)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
 
 
 def test_ccl_cpc_trainer_runs():
@@ -361,5 +361,5 @@ def test_ccl_cpc_trainer_runs():
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
-    loss = trainer.evaluate(loader)
-    assert isinstance(loss, float)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}

--- a/xtylearner/training/active_trainer.py
+++ b/xtylearner/training/active_trainer.py
@@ -96,7 +96,7 @@ class ActiveTrainer:
         self._trainer.fit(num_epochs)
 
     # --------------------------------------------------------------
-    def evaluate(self, data_loader: Iterable) -> float:
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
         return self._trainer.evaluate(data_loader)
 
     # --------------------------------------------------------------

--- a/xtylearner/training/adversarial.py
+++ b/xtylearner/training/adversarial.py
@@ -136,8 +136,8 @@ class AdversarialTrainer(BaseTrainer):
                 self.logger.end_epoch(epoch + 1)
 
     # --------------------------------------------------------------
-    def evaluate(self, data_loader: Iterable) -> float:
-        """Return the generator loss on ``data_loader``.
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
+        """Return metrics on ``data_loader``.
 
         Parameters
         ----------
@@ -146,11 +146,16 @@ class AdversarialTrainer(BaseTrainer):
 
         Returns
         -------
-        float
-            Scalar ``loss_G`` or another metric if available.
+        Mapping[str, float]
+            Dictionary with loss, treatment accuracy and RMSE metrics.
         """
         metrics = self._eval_metrics(data_loader)
-        return metrics.get("loss_G", next(iter(metrics.values()), 0.0))
+        loss_val = metrics.get("loss_G", next(iter(metrics.values()), 0.0))
+        return {
+            "loss": float(loss_val),
+            "treatment accuracy": float(metrics.get("accuracy", 0.0)),
+            "outcome rmse": float(metrics.get("rmse", 0.0)),
+        }
 
     def predict(self, *inputs: torch.Tensor):
         """Return model outputs for ``inputs`` without gradient tracking.

--- a/xtylearner/training/base_trainer.py
+++ b/xtylearner/training/base_trainer.py
@@ -56,8 +56,8 @@ class BaseTrainer(ABC):
         """Train the model for ``num_epochs`` epochs."""
 
     @abstractmethod
-    def evaluate(self, data_loader: Iterable) -> float:
-        """Return a scalar loss/metric evaluated on ``data_loader``."""
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
+        """Return evaluation metrics averaged over ``data_loader``."""
 
     @abstractmethod
     def predict(self, *args, **kwargs):

--- a/xtylearner/training/cotrain.py
+++ b/xtylearner/training/cotrain.py
@@ -93,9 +93,14 @@ class CoTrainTrainer(BaseTrainer):
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
-    def evaluate(self, data_loader: Iterable) -> float:
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
         metrics = self._eval_metrics(data_loader)
-        return metrics.get("loss", next(iter(metrics.values()), 0.0))
+        loss_val = metrics.get("loss", next(iter(metrics.values()), 0.0))
+        return {
+            "loss": float(loss_val),
+            "treatment accuracy": float(metrics.get("accuracy", 0.0)),
+            "outcome rmse": float(metrics.get("rmse", 0.0)),
+        }
 
     def predict(self, *inputs: torch.Tensor):
         self.model.eval()

--- a/xtylearner/training/ctm_trainer.py
+++ b/xtylearner/training/ctm_trainer.py
@@ -67,9 +67,14 @@ class CTMTrainer(BaseTrainer):
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
-    def evaluate(self, data_loader: Iterable) -> float:
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
         metrics = self._eval_metrics(data_loader)
-        return metrics.get("loss", next(iter(metrics.values()), 0.0))
+        loss_val = metrics.get("loss", next(iter(metrics.values()), 0.0))
+        return {
+            "loss": float(loss_val),
+            "treatment accuracy": float(metrics.get("accuracy", 0.0)),
+            "outcome rmse": float(metrics.get("rmse", 0.0)),
+        }
 
     def predict(self, *args):
         self.model.eval()

--- a/xtylearner/training/diffusion.py
+++ b/xtylearner/training/diffusion.py
@@ -60,8 +60,8 @@ class DiffusionTrainer(BaseTrainer):
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
-    def evaluate(self, data_loader: Iterable) -> float:
-        """Compute the average loss over ``data_loader``.
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
+        """Compute averaged metrics over ``data_loader``.
 
         Parameters
         ----------
@@ -70,11 +70,16 @@ class DiffusionTrainer(BaseTrainer):
 
         Returns
         -------
-        float
-            Mean metric extracted from the evaluation routine.
+        Mapping[str, float]
+            Dictionary with loss, treatment accuracy and RMSE metrics.
         """
         metrics = self._eval_metrics(data_loader)
-        return metrics.get("loss", next(iter(metrics.values()), 0.0))
+        loss_val = metrics.get("loss", next(iter(metrics.values()), 0.0))
+        return {
+            "loss": float(loss_val),
+            "treatment accuracy": float(metrics.get("accuracy", 0.0)),
+            "outcome rmse": float(metrics.get("rmse", 0.0)),
+        }
 
     def predict(self, *args):
         """Generate samples or outcome predictions.

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -69,8 +69,8 @@ class GenerativeTrainer(BaseTrainer):
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
-    def evaluate(self, data_loader: Iterable) -> float:
-        """Return the mean loss on ``data_loader``.
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
+        """Return averaged metrics on ``data_loader``.
 
         Parameters
         ----------
@@ -79,11 +79,16 @@ class GenerativeTrainer(BaseTrainer):
 
         Returns
         -------
-        float
-            Scalar metric obtained from :meth:`_eval_metrics`.
+        Mapping[str, float]
+            Dictionary with loss, treatment accuracy and RMSE metrics.
         """
         metrics = self._eval_metrics(data_loader)
-        return metrics.get("loss", next(iter(metrics.values()), 0.0))
+        loss_val = metrics.get("loss", next(iter(metrics.values()), 0.0))
+        return {
+            "loss": float(loss_val),
+            "treatment accuracy": float(metrics.get("accuracy", 0.0)),
+            "outcome rmse": float(metrics.get("rmse", 0.0)),
+        }
 
     def predict(self, x: torch.Tensor, t_val: int) -> torch.Tensor:
         """Predict outcomes for a fixed treatment value.

--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -71,8 +71,8 @@ class SupervisedTrainer(BaseTrainer):
             if self.logger:
                 self.logger.end_epoch(epoch + 1)
 
-    def evaluate(self, data_loader: Iterable) -> float:
-        """Return the primary evaluation metric on ``data_loader``.
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
+        """Return averaged metrics on ``data_loader``.
 
         Parameters
         ----------
@@ -81,11 +81,16 @@ class SupervisedTrainer(BaseTrainer):
 
         Returns
         -------
-        float
-            Scalar metric such as loss or accuracy.
+        Mapping[str, float]
+            Dictionary with loss, treatment accuracy and RMSE metrics.
         """
         metrics = self._eval_metrics(data_loader)
-        return metrics.get("loss", next(iter(metrics.values()), 0.0))
+        loss_val = metrics.get("loss", next(iter(metrics.values()), 0.0))
+        return {
+            "loss": float(loss_val),
+            "treatment accuracy": float(metrics.get("accuracy", 0.0)),
+            "outcome rmse": float(metrics.get("rmse", 0.0)),
+        }
 
     def predict(self, *inputs: torch.Tensor):
         """Return model outputs for ``inputs``.

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -135,8 +135,8 @@ class Trainer:
         """
         self._trainer.fit(num_epochs)
 
-    def evaluate(self, data_loader: Iterable) -> float:
-        """Return the primary metric on ``data_loader``.
+    def evaluate(self, data_loader: Iterable) -> Mapping[str, float]:
+        """Return evaluation metrics on ``data_loader``.
 
         Parameters
         ----------
@@ -145,8 +145,8 @@ class Trainer:
 
         Returns
         -------
-        float
-            Metric reported by the underlying trainer.
+        Mapping[str, float]
+            Metrics reported by the underlying trainer.
         """
         return self._trainer.evaluate(data_loader)
 


### PR DESCRIPTION
## Summary
- update all trainer classes to return `{"loss": x, "treatment accuracy": y, "outcome rmse": z}` from `evaluate`
- adjust factory wrapper and tests for new return type
- install package in tests before running

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da23554ec8324afe8a3b2c4d2c5f8