### PR TITLE
Fix RMSE metric for 1D outputs

### DIFF
--- a/xtylearner/training/base_trainer.py
+++ b/xtylearner/training/base_trainer.py
@@ -223,7 +223,14 @@ class BaseTrainer(ABC):
         if preds is None:
             return {}
 
-        rmse = rmse_loss(preds, y[mask])
+        targets = y[mask]
+        if preds.dim() != targets.dim():
+            if preds.dim() + 1 == targets.dim() and targets.size(-1) == 1:
+                targets = targets.squeeze(-1)
+            elif preds.dim() - 1 == targets.dim() and preds.size(-1) == 1:
+                preds = preds.squeeze(-1)
+
+        rmse = rmse_loss(preds, targets)
         return {"rmse": float(rmse.item())}
 
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- handle mismatched dimensions in `_outcome_metrics`

## Testing
- `pytest tests/generative/test_diffusion_gnn_scm.py::test_diffusion_gnn_scm_predict_and_proba -q`
- `pytest tests/test_metrics_and_utils.py::test_outcome_metrics -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec56eae6883249a41da28fa2e25a0