### PR TITLE
Fix RMSE logging for MeanTeacher

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -16,6 +16,7 @@ from xtylearner.models import EnergyDiffusionImputer, JointEBM, GFlowNetTreatmen
 from xtylearner.models import GANITE
 from xtylearner.models import ProbCircuitModel, LP_KNN, CTMT
 from xtylearner.models import CCL_CPCModel
+from xtylearner.models import MeanTeacher
 
 
 def test_supervised_trainer_runs():
@@ -57,6 +58,19 @@ def test_multitask_handles_missing_labels():
     )
     loader = DataLoader(dataset, batch_size=5)
     model = MultiTask(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+
+
+def test_mean_teacher_outputs_rmse():
+    dataset = load_mixed_synthetic_dataset(
+        n_samples=20, d_x=2, seed=0, label_ratio=0.5
+    )
+    loader = DataLoader(dataset, batch_size=5)
+    model = MeanTeacher(d_x=2, d_y=1, k=2)
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)

--- a/xtylearner/training/base_trainer.py
+++ b/xtylearner/training/base_trainer.py
@@ -199,10 +199,13 @@ class BaseTrainer(ABC):
                 # handle vector t by batching unique values
                 if t.dim() == 0 or t.numel() == 1:
                     return self.predict(x, int(t.item()))
-                preds = torch.zeros(x.size(0), y.size(-1), device=self.device)
+                preds = torch.zeros_like(y)
                 for val in t.unique():
                     idx = t == val
-                    preds[idx] = self.predict(x[idx], int(val.item()))
+                    out = self.predict(x[idx], int(val.item()))
+                    if out.dim() > preds[idx].dim() and out.size(-1) == 1:
+                        out = out.squeeze(-1)
+                    preds[idx] = out
                 return preds
             except Exception:
                 return None


### PR DESCRIPTION
## Summary
- ensure RMSE is computed when predicting outcomes using `predict`
- add regression test covering `MeanTeacher` RMSE computation

## Testing
- `pytest -k test_mean_teacher_outputs_rmse -vv` *(fails: `pytest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed125cb1083249173bf01780d52e6