### PR TITLE
Fix VAT outcome predictions

### DIFF
--- a/tests/test_vat_model.py
+++ b/tests/test_vat_model.py
@@ -17,3 +17,15 @@ def test_vat_basic_shapes():
 
     probs = model.predict_treatment_proba(x, y)
     assert probs.shape == (5, 2)
+
+
+def test_vat_predict_outcome():
+    model = VAT_Model(d_x=3, d_y=1, k=2)
+    x = torch.randn(4, 3)
+    t = torch.randint(0, 2, (4,))
+
+    out = model.predict_outcome(x, t)
+    assert out.shape == (4, 1)
+
+    out_scalar = model.predict_outcome(x, int(t[0].item()))
+    assert out_scalar.shape == (4, 1)

--- a/xtylearner/models/vat.py
+++ b/xtylearner/models/vat.py
@@ -92,6 +92,16 @@ class VAT_Model(nn.Module):
         return self.outcome(torch.cat([x, t_onehot], dim=-1))
 
     # --------------------------------------------------------------
+    @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: int | torch.Tensor) -> torch.Tensor:
+        if isinstance(t, int):
+            t = torch.full((x.size(0),), t, dtype=torch.long, device=x.device)
+        elif t.dim() == 0:
+            t = t.expand(x.size(0)).to(torch.long)
+        t_onehot = F.one_hot(t.to(torch.long), self.k).float()
+        return self.outcome(torch.cat([x, t_onehot], dim=-1))
+
+    # --------------------------------------------------------------
     def loss(
         self, x: torch.Tensor, y: torch.Tensor, t_obs: torch.Tensor
     ) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- allow retrieving outcome predictions from VAT models
- test VAT's predict_outcome API

## Testing
- `pytest -vv -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687ed1042780832498a964192b6b80b2