### PR TITLE
Fix missing rmse metric for FixMatch

### DIFF
--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -107,7 +107,10 @@ class SupervisedTrainer(BaseTrainer):
         """
         self.model.eval()
         with torch.no_grad():
-            inputs = [i.to(self.device) for i in inputs]
+            inputs = [
+                i.to(self.device) if isinstance(i, torch.Tensor) else i
+                for i in inputs
+            ]
             if hasattr(self.model, "predict"):
                 return self.model.predict(*inputs)
             return self.model(*inputs)


### PR DESCRIPTION
## Summary
- avoid `.to()` on non-tensor inputs in `SupervisedTrainer.predict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ed1784ed08324a4480e4ebcd50363