### PR TITLE
Fix CTMT input dimension inference

### DIFF
--- a/tests/models/test_ctm_t.py
+++ b/tests/models/test_ctm_t.py
@@ -1,0 +1,13 @@
+import torch
+from xtylearner.models import CTMT
+
+
+def test_ctmt_inferred_d_in_and_forward():
+    model = CTMT(d_x=3, d_y=2, k=4)
+    assert model.d_in == 3 + 2 + 1
+    x = torch.randn(5, model.d_in)
+    t = torch.zeros(5, 1)
+    delta = torch.zeros(5, 1)
+    out, logits = model(x, t, delta)
+    assert out.shape == (5, model.d_in)
+    assert logits.shape == (5, 4)

--- a/xtylearner/models/ctm_t.py
+++ b/xtylearner/models/ctm_t.py
@@ -21,10 +21,10 @@ class CTMT(nn.Module):
         d_y: int | None = None,
         k: int | None = None,
     ) -> None:
-        if d_in is None and d_x is None:
-            raise TypeError("d_in or d_x must be specified")
-        if d_x is not None:
-            d_in = d_x
+        if d_in is None:
+            if d_x is None or d_y is None:
+                raise TypeError("d_in or both d_x and d_y must be specified")
+            d_in = d_x + d_y + 1
         if k is not None:
             d_treat = k
         super().__init__()


### PR DESCRIPTION
## Summary
- compute CTMT `d_in` from `d_x` and `d_y` when provided
- add regression test for CTMT initialisation

## Testing
- `pre-commit run --files xtylearner/models/ctm_t.py tests/models/test_ctm_t.py`
- `pytest tests/models/test_ctm_t.py tests/test_trainer.py::test_ctm_trainer_runs -vv`

------
https://chatgpt.com/codex/tasks/task_e_687ee49a7d20832485a2f8afde639aef