### PR TITLE
Fix dtype mismatch in DeconfounderCFM

### DIFF
--- a/xtylearner/models/components.py
+++ b/xtylearner/models/components.py
@@ -38,6 +38,7 @@ class VAE_T(nn.Module):
             Latent representation ``z`` with dimension ``d_z``.
         """
 
+        t = t.float()
         t_filled = torch.nan_to_num(t, 0.0)
         mu = self.enc_mu(t_filled)
         logv = self.enc_log(t_filled).clamp(-8, 8)
@@ -51,7 +52,7 @@ class VAE_T(nn.Module):
     # ------------------------------------------------------------------
     def elbo(self, t: torch.Tensor) -> torch.Tensor:
         """Return the evidence lower bound for a batch of treatments."""
-
+        t = t.float()
         mask = torch.isfinite(t)
         t_filled = torch.nan_to_num(t, 0.0)
         mu = self.enc_mu(t_filled)

--- a/xtylearner/models/deconfounder_model.py
+++ b/xtylearner/models/deconfounder_model.py
@@ -56,7 +56,7 @@ class DeconfounderCFM(nn.Module):
             return self.vae_t.elbo(t)
         elbo_t = self.vae_t.elbo(t)
         z = self.vae_t.encode(t, sample=False).detach()
-        inp = torch.cat([x, torch.nan_to_num(t, 0.0), z], 1)
+        inp = torch.cat([x, torch.nan_to_num(t.float(), 0.0), z], 1)
         pred = self.out_net(inp)
         loss_y = F.mse_loss(pred, y)
         return elbo_t + loss_y
@@ -65,7 +65,7 @@ class DeconfounderCFM(nn.Module):
     @torch.no_grad()
     def predict_outcome(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
         z = self.vae_t.encode(t, sample=False)
-        inp = torch.cat([x, torch.nan_to_num(t, 0.0), z], 1)
+        inp = torch.cat([x, torch.nan_to_num(t.float(), 0.0), z], 1)
         return self.out_net(inp)
 
     @torch.no_grad()
@@ -89,7 +89,7 @@ class DeconfounderCFM(nn.Module):
         self.epoch += 1
         if t is not None and self.epoch.item() % self.ppc_freq == 0:
             z = self.vae_t.encode(t, sample=False)
-            ppc = _hsic(torch.nan_to_num(t, 0.0), z)
+            ppc = _hsic(torch.nan_to_num(t.float(), 0.0), z)
             if hasattr(self, "logger"):
                 self.logger.log_scalar("ppc_hsic", float(ppc))
 


### PR DESCRIPTION
## Summary
- ensure DeconfounderCFM accepts integer treatment tensors
- cast treatment inputs to float in `VAE_T` and `DeconfounderCFM`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee481cf10832488ac19723d175842