### PR TITLE
Extend masked_tabular_transformer to multiple outcomes

### DIFF
--- a/tests/test_masked_tabular_transformer.py
+++ b/tests/test_masked_tabular_transformer.py
@@ -1,5 +1,5 @@
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, TensorDataset
 
 from xtylearner.data import load_mixed_synthetic_dataset
 from xtylearner.models import MaskedTabularTransformer
@@ -23,3 +23,23 @@ def test_masked_tabular_transformer_runs():
     y0 = model.predict_y(x_row, t_prompt=0, n_samples=2)
     y1 = model.predict_y(x_row, t_prompt=1, n_samples=2)
     assert isinstance(y0, float) and isinstance(y1, float)
+
+
+def test_masked_tabular_transformer_multi_y():
+    ds = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=1, label_ratio=0.7)
+    X, Y, T = ds.tensors
+    Y_multi = torch.cat([Y, Y + 1.0], dim=1)
+    ds_multi = TensorDataset(X, Y_multi, T)
+
+    model = MaskedTabularTransformer(d_x=2, d_y=2, y_bins=8, d_model=16, num_layers=2)
+    model.set_y_range(float(Y_multi.min()), float(Y_multi.max()))
+
+    loader = DataLoader(ds_multi, batch_size=5)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+    metrics = trainer.evaluate(loader)
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+
+    out = model.predict_y(X[0], t_prompt=0)
+    assert isinstance(out, torch.Tensor) and out.shape == (2,)

--- a/xtylearner/models/masked_tabular_transformer.py
+++ b/xtylearner/models/masked_tabular_transformer.py
@@ -40,23 +40,21 @@ class MaskedTabularTransformer(nn.Module):
         p_mask: float = 0.15,
     ) -> None:
         super().__init__()
-        if d_y != 1:
-            raise ValueError(
-                "MaskedTabularTransformer only supports a single outcome (d_y=1)"
-            )
+        if d_y < 1:
+            raise ValueError("d_y must be >= 1")
         self.d_x = d_x
         self.d_y = d_y
         self.k = k
         self.y_bins = y_bins
         self.d_model = d_model
         self.p_mask = p_mask
-        self.seq_len = d_x + 5
+        self.seq_len = d_x + 2 * d_y + 3
 
         self.num_emb = nn.ModuleList([NumEmbed(d_model) for _ in range(d_x)])
         self.tok_T = nn.Embedding(k + 1, d_model)
         self.tok_Y = nn.Embedding(y_bins + 1, d_model)
         self.tok_special = nn.Embedding(3, d_model)
-        self.pos_emb = nn.Embedding(d_x + 6, d_model)
+        self.pos_emb = nn.Embedding(self.seq_len + 1, d_model)
 
         layer = nn.TransformerEncoderLayer(
             d_model, nhead=nhead, dim_feedforward=dim_feedforward
@@ -65,15 +63,23 @@ class MaskedTabularTransformer(nn.Module):
         self.head_T = nn.Linear(d_model, k)
         self.head_Y = nn.Linear(d_model, y_bins)
 
-        self.register_buffer("y_min", torch.tensor(0.0))
-        self.register_buffer("y_max", torch.tensor(1.0))
+        self.register_buffer("y_min", torch.zeros(d_y))
+        self.register_buffer("y_max", torch.ones(d_y))
 
     # ------------------------------------------------------------------
-    def set_y_range(self, y_min: float, y_max: float) -> None:
+    def set_y_range(self, y_min: float | torch.Tensor, y_max: float | torch.Tensor) -> None:
         """Set min/max outcome values for discretisation."""
 
-        self.y_min.fill_(float(y_min))
-        self.y_max.fill_(float(y_max))
+        y_min_t = torch.as_tensor(y_min, dtype=torch.float32, device=self.y_min.device)
+        y_max_t = torch.as_tensor(y_max, dtype=torch.float32, device=self.y_max.device)
+        if y_min_t.numel() == 1:
+            self.y_min.fill_(float(y_min_t))
+            self.y_max.fill_(float(y_max_t))
+        else:
+            if y_min_t.numel() != self.d_y or y_max_t.numel() != self.d_y:
+                raise ValueError("y_min/y_max must have length d_y")
+            self.y_min.copy_(y_min_t.view(-1))
+            self.y_max.copy_(y_max_t.view(-1))
 
     # ------------------------------------------------------------------
     def _discretise_y(self, y: torch.Tensor) -> torch.Tensor:
@@ -87,18 +93,19 @@ class MaskedTabularTransformer(nn.Module):
         b = x.size(0)
         device = x.device
         seqs = []
+        y_nan = torch.full((self.d_y,), float("nan"), device=device)
         for i in range(b):
-            row = self.row_to_tokens(
-                x[i], torch.tensor(float("nan"), device=device), t[i]
-            )
+            row = self.row_to_tokens(x[i], y_nan, t[i])
             seqs.append(row)
         tok_matrix = torch.stack(seqs)
         idx = torch.arange(self.seq_len, device=device)
         out = self.encoder((tok_matrix + self.pos_emb(idx)).transpose(0, 1)).transpose(
             0, 1
         )
-        logits = self.head_Y(out[:, self.d_x + 4])
-        return logits
+        logits = []
+        for j in range(self.d_y):
+            logits.append(self.head_Y(out[:, self.d_x + 4 + 2 * j]))
+        return torch.stack(logits, dim=1)
 
     # ------------------------------------------------------------------
     @torch.no_grad()
@@ -108,8 +115,10 @@ class MaskedTabularTransformer(nn.Module):
         logits = self.forward(x, t)
         probs = logits.softmax(dim=-1)
         bins = torch.linspace(0, self.y_bins - 1, self.y_bins, device=logits.device)
-        vals = self.y_min + bins / (self.y_bins - 1) * (self.y_max - self.y_min)
-        return (probs * vals).sum(-1, keepdim=True)
+        vals = self.y_min.unsqueeze(-1) + bins / (self.y_bins - 1) * (
+            self.y_max - self.y_min
+        ).unsqueeze(-1)
+        return (probs * vals).sum(-1)
 
     # ------------------------------------------------------------------
     def row_to_tokens(
@@ -122,12 +131,14 @@ class MaskedTabularTransformer(nn.Module):
         tokens.append(self.tok_special(torch.tensor([self.TOK_T], device=device)))
         t_tok = self.k if int(t_val) == -1 else int(t_val)
         tokens.append(self.tok_T(torch.tensor([t_tok], device=device)))
-        tokens.append(self.tok_special(torch.tensor([self.TOK_Y], device=device)))
-        if torch.isnan(y_disc):
-            y_tok = self.y_bins
-        else:
-            y_tok = int(y_disc)
-        tokens.append(self.tok_Y(torch.tensor([y_tok], device=device)))
+        for j in range(self.d_y):
+            tokens.append(self.tok_special(torch.tensor([self.TOK_Y], device=device)))
+            val_disc = y_disc[j]
+            if torch.isnan(val_disc):
+                y_tok = self.y_bins
+            else:
+                y_tok = int(val_disc)
+            tokens.append(self.tok_Y(torch.tensor([y_tok], device=device)))
         return torch.cat(tokens, 0)
 
     # ------------------------------------------------------------------
@@ -136,11 +147,11 @@ class MaskedTabularTransformer(nn.Module):
     ) -> torch.Tensor:
         b = x.size(0)
         device = x.device
-        y_disc = self._discretise_y(y.view(-1))
+        y_disc = self._discretise_y(y)
 
         tok_matrix = torch.zeros(b, self.seq_len, self.d_model, device=device)
         labels_T = torch.full((b,), -100, dtype=torch.long, device=device)
-        labels_Y = torch.full((b,), -100, dtype=torch.long, device=device)
+        labels_Y = torch.full((b, self.d_y), -100, dtype=torch.long, device=device)
 
         for i in range(b):
             row = self.row_to_tokens(x[i], y_disc[i], t_obs[i])
@@ -151,7 +162,8 @@ class MaskedTabularTransformer(nn.Module):
         mask_mask = torch.rand(b, self.seq_len, device=device) < self.p_mask
         mask_mask[:, 0] = False
         mask_mask[:, self.d_x + 1] = False
-        mask_mask[:, self.d_x + 3] = False
+        for j in range(self.d_y):
+            mask_mask[:, self.d_x + 3 + 2 * j] = False
         mask_mask[t_obs == -1, self.d_x + 2] = True
 
         mask_vec = self.tok_T(torch.tensor([self.k], device=device))
@@ -162,21 +174,26 @@ class MaskedTabularTransformer(nn.Module):
         out = self.encoder(tok_matrix.transpose(0, 1)).transpose(0, 1)
 
         logits_T = self.head_T(out[:, self.d_x + 2])
-        logits_Y = self.head_Y(out[:, self.d_x + 4])
-
         loss_T = F.cross_entropy(logits_T, labels_T, ignore_index=-100)
-        loss_Y = F.cross_entropy(logits_Y, labels_Y)
+
+        loss_Y = 0.0
+        for j in range(self.d_y):
+            logits_Y = self.head_Y(out[:, self.d_x + 4 + 2 * j])
+            loss_Y = loss_Y + F.cross_entropy(logits_Y, labels_Y[:, j])
+        loss_Y = loss_Y / self.d_y
         return loss_T + loss_Y
 
     # ------------------------------------------------------------------
     @torch.no_grad()
     def predict_y(
         self, x_row: torch.Tensor, t_prompt: int, n_samples: int = 20
-    ) -> float:
+    ) -> torch.Tensor | float:
         pred = self.predict_outcome(
             x_row.unsqueeze(0), torch.tensor([t_prompt], device=x_row.device)
         )
-        return float(pred.item())
+        if self.d_y == 1:
+            return float(pred.squeeze(0).item())
+        return pred.squeeze(0)
 
     # ------------------------------------------------------------------
     @torch.no_grad()
@@ -185,7 +202,7 @@ class MaskedTabularTransformer(nn.Module):
 
         b = x.size(0)
         device = x.device
-        y_disc = self._discretise_y(y.view(-1))
+        y_disc = self._discretise_y(y)
         seqs = []
         for i in range(b):
             row = self.row_to_tokens(x[i], y_disc[i], torch.tensor(-1, device=device))


### PR DESCRIPTION
## Summary
- allow `MaskedTabularTransformer` to operate on `d_y>=1`
- handle vector outcome range and discretisation
- update loss, forward and helpers for multi-output
- test multi-output case

## Testing
- `pytest -q tests/test_masked_tabular_transformer.py`
- `pytest -q tests/test_registry.py::test_get_model_valid -k masked_tabular_transformer`

------
https://chatgpt.com/codex/tasks/task_e_687ee45378bc8324ab723ac1714030c7