### PR TITLE
Fix VIME output dimension mismatch

### DIFF
--- a/xtylearner/models/vime.py
+++ b/xtylearner/models/vime.py
@@ -53,7 +53,7 @@ class VIME(nn.Module):
             norm_layer=norm_layer,
         )
         self.classifier = make_mlp(
-            [self.encoder.out_dim, *hidden_dims, d_y],
+            [self.encoder.out_dim, *hidden_dims, k],
             activation=activation,
             dropout=dropout,
             norm_layer=norm_layer,


### PR DESCRIPTION
## Summary
- use the number of classes (`k`) for the VIME classifier output

## Testing
- `pytest tests/test_vime_model.py::test_vime_basic_training -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef262363c8324acddd40f51228de1