### PR TITLE
Fix MeanTeacher RMSE logging

### DIFF
--- a/tests/test_logger_noise.py
+++ b/tests/test_logger_noise.py
@@ -3,6 +3,10 @@ import pytest
 
 from xtylearner.noise_schedules import add_noise
 from xtylearner.training.logger import ConsoleLogger
+from xtylearner.training import Trainer
+from xtylearner.models import MeanTeacher
+from xtylearner.data import load_mixed_synthetic_dataset
+from torch.utils.data import DataLoader
 
 
 def test_add_noise_deterministic():
@@ -40,3 +44,14 @@ def test_console_logger_outputs_and_averages(capsys):
     assert "Epoch 1 validation: val=0.5000" in out
     assert "Epoch 1 finished:" in out
     assert logger.averages()["loss"] == pytest.approx(2.0)
+
+
+def test_mean_teacher_logger_emits_rmse(capsys):
+    dataset = load_mixed_synthetic_dataset(n_samples=20, d_x=2, seed=0, label_ratio=0.5)
+    loader = DataLoader(dataset, batch_size=5)
+    model = MeanTeacher(d_x=2, d_y=1, k=2)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = Trainer(model, opt, loader, logger=ConsoleLogger(print_every=1))
+    trainer.fit(1)
+    out = capsys.readouterr().out
+    assert "rmse=" in out

--- a/xtylearner/models/mean_teacher.py
+++ b/xtylearner/models/mean_teacher.py
@@ -107,6 +107,18 @@ class MeanTeacher(nn.Module):
 
     # --------------------------------------------------------------
     @torch.no_grad()
+    def predict_outcome(self, x: torch.Tensor, t: int | torch.Tensor) -> torch.Tensor:
+        """Return outcome predictions for covariates ``x`` and treatment ``t``."""
+
+        if isinstance(t, int):
+            t = torch.full((x.size(0),), t, dtype=torch.long, device=x.device)
+        elif t.dim() == 0:
+            t = t.expand(x.size(0)).to(torch.long)
+        t_onehot = F.one_hot(t.to(torch.long), self.k).float()
+        return self.outcome(torch.cat([x, t_onehot], dim=-1))
+
+    # --------------------------------------------------------------
+    @torch.no_grad()
     def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         logits = self.teacher(torch.cat([x, y], dim=-1))
         return logits.softmax(dim=-1)


### PR DESCRIPTION
## Summary
- add `predict_outcome` to `MeanTeacher`
- ensure RMSE is logged by the ConsoleLogger
- test that MeanTeacher training prints RMSE

## Testing
- `pytest tests/test_trainer.py::test_mean_teacher_outputs_rmse -q`
- `pytest tests/test_logger_noise.py::test_mean_teacher_logger_emits_rmse -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef2a8437c8324b7c7672525be034b