### PR TITLE
Fix default outcome prediction for LP_KNN

### DIFF
--- a/xtylearner/models/labelprop.py
+++ b/xtylearner/models/labelprop.py
@@ -80,7 +80,9 @@ class LP_KNN:
     # ------------------------------------------------------------------
     def predict_outcome(self, X, t):
         if self.regressor is None:
-            return np.zeros((len(X), 1))
+            if not hasattr(self.clf, "classes_"):
+                return np.zeros((len(X), 1))
+            raise ValueError("Outcome regressor not set")
         t_arr = np.asarray(t, dtype=int)
         X_reg = np.concatenate([X, self._one_hot(t_arr)], axis=1)
         return self.regressor.predict(X_reg)


### PR DESCRIPTION
## Summary
- ensure `LP_KNN.predict_outcome` only raises when an unfitted regressor is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f02906c5c8324850782ac4f56d795