### PR TITLE
Fix multi-outcome masking in SCGM

### DIFF
--- a/xtylearner/models/scgm.py
+++ b/xtylearner/models/scgm.py
@@ -106,7 +106,8 @@ class SCGM(nn.Module):
 
         log_px = -F.mse_loss(out["x_hat"], x, reduction="none").sum(-1)
         log_pt = -F.cross_entropy(out["t_logits"], t_clean, reduction="none")
-        log_py = -F.mse_loss(out["y_hat"], y_filled, reduction="none").sum(-1)
+        log_py = -F.mse_loss(out["y_hat"], y_filled, reduction="none")
+        log_py = (mask_y.float() * log_py).sum(-1)
 
         zeros = torch.zeros_like(out["z_mu"])
         kl_z = kl_normal(out["z_mu"], out["z_logvar"], zeros, zeros)
@@ -119,7 +120,7 @@ class SCGM(nn.Module):
         elbo = (
             log_px
             + mask_t.float() * log_pt
-            + mask_y.float() * log_py
+            + log_py
             - kl_z
             - (1.0 - mask_t.float()) * kl_t
         )


### PR DESCRIPTION
## Summary
- fix dimension mismatch when SCGM handles multiple outcomes

## Testing
- `pytest -q tests/models/test_scgm.py::test_scgm_trainer_runs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f0347d18c8324b3e0a684d3095401