### PR TITLE
Fix invalid escape sequence warning

### DIFF
--- a/xtylearner/models/ctm_t.py
+++ b/xtylearner/models/ctm_t.py
@@ -46,7 +46,7 @@ class CTMT(nn.Module):
 
     @torch.no_grad()
     def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        """Return :math:`p(t\mid x,y)` inferred by the propensity head."""
+        r"""Return :math:`p(t\mid x,y)` inferred by the propensity head."""
         zeros = torch.zeros(x.size(0), 1, device=x.device)
         x0 = torch.cat([x, y, zeros], dim=-1)
         _, logits = self.forward(x0, zeros, zeros)


### PR DESCRIPTION
## Summary
- fix invalid escape sequence in `CTMT` docstring

## Testing
- `pytest tests/models/test_ctm_t.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f089ffa1c8324949e2b713ec9619f