### PR TITLE
Add per-split outcome RMSE logging

### DIFF
--- a/tests/test_logger_noise.py
+++ b/tests/test_logger_noise.py
@@ -54,4 +54,4 @@ def test_mean_teacher_logger_emits_rmse(capsys):
     trainer = Trainer(model, opt, loader, logger=ConsoleLogger(print_every=1))
     trainer.fit(1)
     out = capsys.readouterr().out
-    assert "rmse=" in out
+    assert "rmse_labelled=" in out

--- a/tests/test_metrics_and_utils.py
+++ b/tests/test_metrics_and_utils.py
@@ -113,5 +113,6 @@ def test_outcome_metrics():
     assert metrics["rmse"] == pytest.approx(0.0)
 
     metrics = trainer._outcome_metrics(x, y, torch.tensor([-1, -1]))
-    assert metrics == {}
+    assert metrics["rmse_unlabelled"] == pytest.approx(0.0)
+    assert metrics["rmse"] == pytest.approx(0.0)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -27,7 +27,13 @@ def test_supervised_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {
+        "loss",
+        "treatment accuracy",
+        "outcome rmse",
+        "outcome rmse labelled",
+        "outcome rmse unlabelled",
+    }
 
 
 def test_flow_model_runs():
@@ -38,7 +44,7 @@ def test_flow_model_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_multitask_model_runs():
@@ -49,7 +55,7 @@ def test_multitask_model_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_multitask_handles_missing_labels():
@@ -62,7 +68,7 @@ def test_multitask_handles_missing_labels():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_mean_teacher_outputs_rmse():
@@ -75,7 +81,7 @@ def test_mean_teacher_outputs_rmse():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_dragon_net_runs():
@@ -86,7 +92,7 @@ def test_dragon_net_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_dragon_net_multi_outcome():
@@ -107,7 +113,7 @@ def test_dragon_net_multi_outcome():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_m2vae_trainer_runs():
@@ -118,7 +124,7 @@ def test_m2vae_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_cevae_trainer_runs():
@@ -129,7 +135,7 @@ def test_cevae_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_supervised_trainer_mixed_dataset():
@@ -140,7 +146,7 @@ def test_supervised_trainer_mixed_dataset():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_cevae_trainer_mixed_dataset():
@@ -151,7 +157,7 @@ def test_cevae_trainer_mixed_dataset():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_jsbf_trainer_runs():
@@ -162,7 +168,7 @@ def test_jsbf_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_diffusion_cevae_trainer_runs():
@@ -173,7 +179,7 @@ def test_diffusion_cevae_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_bridge_diff_trainer_runs():
@@ -184,7 +190,7 @@ def test_bridge_diff_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_lt_flow_diff_trainer_runs():
@@ -197,7 +203,7 @@ def test_lt_flow_diff_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_eg_ddi_trainer_runs():
@@ -210,7 +216,7 @@ def test_eg_ddi_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_joint_ebm_trainer_runs():
@@ -223,7 +229,7 @@ def test_joint_ebm_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_gflownet_treatment_trainer_runs():
@@ -236,7 +242,7 @@ def test_gflownet_treatment_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_ganite_trainer_runs():
@@ -250,7 +256,7 @@ def test_ganite_trainer_runs():
     trainer = Trainer(model, (opt_g, opt_d), loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 def test_ganite_with_schedulers():
     dataset = load_mixed_synthetic_dataset(
@@ -349,7 +355,7 @@ def test_labelprop_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_ctm_trainer_runs():
@@ -363,7 +369,7 @@ def test_ctm_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}
 
 
 def test_ccl_cpc_trainer_runs():
@@ -376,4 +382,4 @@ def test_ccl_cpc_trainer_runs():
     trainer = Trainer(model, opt, loader)
     trainer.fit(1)
     metrics = trainer.evaluate(loader)
-    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse"}
+    assert set(metrics) >= {"loss", "treatment accuracy", "outcome rmse", "outcome rmse labelled", "outcome rmse unlabelled"}

--- a/xtylearner/training/adversarial.py
+++ b/xtylearner/training/adversarial.py
@@ -155,6 +155,8 @@ class AdversarialTrainer(BaseTrainer):
             "loss": float(loss_val),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, *inputs: torch.Tensor):

--- a/xtylearner/training/cotrain.py
+++ b/xtylearner/training/cotrain.py
@@ -101,6 +101,8 @@ class CoTrainTrainer(BaseTrainer):
             "loss": float(loss_val),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, *inputs: torch.Tensor):

--- a/xtylearner/training/ctm_trainer.py
+++ b/xtylearner/training/ctm_trainer.py
@@ -74,6 +74,8 @@ class CTMTrainer(BaseTrainer):
             "loss": float(loss_val),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, *args):

--- a/xtylearner/training/diffusion.py
+++ b/xtylearner/training/diffusion.py
@@ -79,6 +79,8 @@ class DiffusionTrainer(BaseTrainer):
             "loss": float(loss_val),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, *args):

--- a/xtylearner/training/em.py
+++ b/xtylearner/training/em.py
@@ -156,6 +156,8 @@ class ArrayTrainer(BaseTrainer):
             "loss": float(metrics.get("loss", 0.0)),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, x: torch.Tensor, t_val: int | None = None):

--- a/xtylearner/training/generative.py
+++ b/xtylearner/training/generative.py
@@ -88,6 +88,8 @@ class GenerativeTrainer(BaseTrainer):
             "loss": float(loss_val),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, x: torch.Tensor, t_val: int) -> torch.Tensor:

--- a/xtylearner/training/supervised.py
+++ b/xtylearner/training/supervised.py
@@ -90,6 +90,8 @@ class SupervisedTrainer(BaseTrainer):
             "loss": float(loss_val),
             "treatment accuracy": float(metrics.get("accuracy", 0.0)),
             "outcome rmse": float(metrics.get("rmse", 0.0)),
+            "outcome rmse labelled": float(metrics.get("rmse_labelled", 0.0)),
+            "outcome rmse unlabelled": float(metrics.get("rmse_unlabelled", 0.0)),
         }
 
     def predict(self, *inputs: torch.Tensor):


### PR DESCRIPTION
## Summary
- compute separate labelled and unlabelled RMSE in `BaseTrainer`
- surface the new metrics from all trainer `evaluate` methods
- check logger output for the new metric
- update tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2ff0426083249ede1bc4c6e26474