### PR TITLE
Refactor CNF model to condition on treatment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ The model registry exposes a variety of architectures grouped below by type.
 
 - ``MixtureOfFlows`` – a semi-supervised conditional normalising flow
   combining an invertible network with a classifier.
-- ``CNFlowModel`` – a conditional normalising flow modelling the joint
-  distribution ``(Y, T)`` given ``X``.
+- ``CNFlowModel`` – a conditional normalising flow modelling
+  ``p(Y\mid X,T)``.
 - ``M2VAE`` – a generative model based on the M2 variational autoencoder.
 - ``SS_CEVAE`` – a semi-supervised extension of the CEVAE framework.
 - ``CEVAE_M`` – CEVAE with latent treatment for partially-observed labels.


### PR DESCRIPTION
## Summary
- refactor `CNFlowModel` so treatment is context not a flow variable
- swap identity transforms for random permutations
- simplify sampling and missing-label handling
- update README description

## Testing
- `pip install -e .`
- `pytest tests/test_cnflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5a27b1088324bacce8787d12e855