### PR TITLE
Add t|x,y head to SemiITE

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The model registry exposes a variety of architectures grouped below by type.
 - ``MaskedTabularTransformer`` – a transformer encoder for tabular data using a
   masked-token training objective.
 - ``SemiITE`` – a co-training network for semi-supervised treatment effect
-  estimation.
+  estimation with a reconstruction head for ``p(t\|x,y)``.
 - ``CCL_CPCModel`` – a contrastive predictive coding model for sequential
   covariates and partially observed labels.
 


### PR DESCRIPTION
## Summary
- extend SemiITE with a reconstruction head that predicts treatment from covariates and outcomes
- train new head via cross entropy and KL regularisation in `CoTrainTrainer`
- mention p(t|x,y) reconstruction in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fef459c88324930b051f695cd69d