### PR TITLE
Improve lt_flow_diff

### DIFF
--- a/tests/test_lt_flow_diff.py
+++ b/tests/test_lt_flow_diff.py
@@ -1,0 +1,27 @@
+import torch
+from xtylearner.models import LTFlowDiff
+
+
+def test_flow_inverse_consistency():
+    d_x, d_y, k = 3, 2, 2
+    model = LTFlowDiff(d_x=d_x, d_y=d_y, k=k)
+    x = torch.randn(16, d_x)
+    y = torch.randn(16, d_y)
+    z = torch.randn(16, model.d_z)
+    t = torch.randint(0, k, (16,))
+    u, ld = model.flow(y, x, z, t)
+    y_rec, ld_inv = model.flow.inverse(u, x, z, t)
+    assert torch.allclose(y, y_rec, atol=1e-4)
+    assert ld.shape == ld_inv.shape
+
+
+def test_score_output():
+    model = LTFlowDiff(d_x=2, d_y=1)
+    z = torch.randn(1, model.d_z)
+    t = torch.zeros(1, dtype=torch.long)
+    sig = model._sigma(torch.tensor([0.5]))
+    eps = torch.randn_like(z)
+    z_tau = z + sig * eps
+    s = model.score(z_tau, t, tau=torch.tensor([[0.5]]))
+    assert torch.isfinite(s).all()
+


### PR DESCRIPTION
## Summary
- fix base shift location and logdet shapes in `CondFlow`
- update pseudo-label logic and regularization
- implement SGLD sampler noise schedule with optional parameters
- expose sampler step size in API methods
- add unit tests for `LTFlowDiff`

## Testing
- `pytest tests/test_lt_flow_diff.py::test_flow_inverse_consistency -q`
- `pytest tests/test_lt_flow_diff.py::test_score_output -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688408d04f4c8324a29daf06f1bd3da3