### PR TITLE
Fix benchmark CI workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,14 +18,18 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
             requirements.txt
-      - name: Restore venv
-        id: restore-venv
-        uses: actions/cache/restore@v4
+      - name: Restore or save venv
+        id: cache-venv
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-py3.11-${{ hashFiles('requirements.txt') }}
+
+      - name: Ensure .venv on PATH
+        if: steps.cache-venv.outputs.cache-hit == 'true'
+        run: echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
       - name: Build venv if needed
-        if: steps.restore-venv.outputs.cache-hit != 'true'
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         env:
           PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
         run: |
@@ -37,8 +41,9 @@ jobs:
         env:
           PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
         run: |
+          source .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install 'torch==2.3.1+cpu' -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu
           pip install -e .
       - name: Run benchmark
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.3.1+cpu
+torch==2.3.0
 scikit-learn==1.7.0
 numpy==2.3.1
 nflows==0.14


### PR DESCRIPTION
## Summary
- ensure `.venv/bin` is on PATH when the cache is restored
- cache the venv using `actions/cache@v4`
- run all installs inside the venv and pin torch 2.3.0
- update requirements to match

## Testing
- `pre-commit run --files .github/workflows/benchmark.yml requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884364e568c83248aa393c0449e83c7