### PR TITLE
Fix YAML syntax in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,9 +49,9 @@ jobs:
         run: |
           . .venv/bin/activate
           python - <<'PY'
-from examples.benchmark_models import run_benchmark
-run_benchmark('benchmark_results.md')
-PY
+          from examples.benchmark_models import run_benchmark
+          run_benchmark('benchmark_results.md')
+          PY
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- fix indentation in benchmark workflow to avoid Python heredoc IndentationError

## Testing
- `pre-commit run --files .github/workflows/benchmark.yml`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688438b90f6c83249fd7a53c28c306be