### PR TITLE
Install tabulate for benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,9 +49,9 @@ jobs:
         run: |
           . .venv/bin/activate
           python - <<'PY'
-from examples.benchmark_models import run_benchmark
-run_benchmark('benchmark_results.md')
-PY
+          from examples.benchmark_models import run_benchmark
+          run_benchmark('benchmark_results.md')
+          PY
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyyaml",
     "pandas",
     "scipy",
+    "tabulate",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ nflows==0.14
 pyyaml==6.0.2
 pandas==2.3.0
 scipy==1.16.0
+tabulate==0.9.0
 pytest
 pytest-xdist


### PR DESCRIPTION
## Summary
- include `tabulate` so pandas DataFrame.to_markdown works
- keep benchmark workflow heredoc formatting

## Testing
- `pre-commit run --files requirements.txt pyproject.toml .github/workflows/benchmark.yml`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688438b90f6c83249fd7a53c28c306be