### PR TITLE
Improve lt_flow_diff readability and correctness

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,7 +3,7 @@ import pytest
 from torch.utils.data import DataLoader, TensorDataset
 
 from xtylearner.configs import load as load_config
-from xtylearner.models.lt_flow_diff import _sigma
+from xtylearner.models.lt_flow_diff import sigma_schedule
 from xtylearner.training import ArrayTrainer
 
 
@@ -21,8 +21,8 @@ def test_config_load(tmp_path):
 
 def test_sigma_schedule_bounds():
     smin, smax = 0.1, 1.0
-    assert _sigma(torch.tensor(0.0), smin, smax).item() == pytest.approx(smin)
-    assert _sigma(torch.tensor(1.0), smin, smax).item() == pytest.approx(smax)
+    assert sigma_schedule(torch.tensor(0.0), smin, smax).item() == pytest.approx(smin)
+    assert sigma_schedule(torch.tensor(1.0), smin, smax).item() == pytest.approx(smax)
 
 
 def test_collect_arrays_shapes():


### PR DESCRIPTION
## Summary
- improve `lt_flow_diff` implementation
  - rename sigma scheduler and use `itertools.chain`
  - clarify shapes and behaviour in docstrings
  - clamp encoder variance via parameter
  - fix logdet shape handling
  - minor regularisation comments
- update tests for new helper name

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68844a10e6dc8324bf892246e4ca96cf