### PR TITLE
Fix duplicate benchmark workflow runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,12 @@
 name: Benchmark Models
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize]
 
 jobs:
   benchmark:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- trigger benchmarks only on pull request events
- skip workflow if triggered by the github-actions bot

## Testing
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884a6870c548324924b69cd6b5255cf