### PR TITLE
Handle continuous treatments in trainer utilities

### DIFF
--- a/tests/test_metrics_and_utils.py
+++ b/tests/test_metrics_and_utils.py
@@ -12,6 +12,7 @@ from xtylearner.training.metrics import (
 )
 from xtylearner.models.utils import ramp_up_sigmoid
 from xtylearner.training.base_trainer import BaseTrainer
+from xtylearner.models import GNN_SCM
 
 
 class DummyModel(torch.nn.Module):
@@ -24,6 +25,16 @@ class DummyModel(torch.nn.Module):
 
     def predict_outcome(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
         return 2 * x[:, :1]
+
+
+class DummyContinuousModel(DummyModel):
+    def __init__(self):
+        super().__init__()
+        self.k = None
+
+    def predict_treatment_proba(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        params = torch.tensor([[0.0, 1.0]], device=x.device)
+        return params.repeat(x.size(0), 1)
 
 
 class DummyTrainer(BaseTrainer):
@@ -39,6 +50,12 @@ class DummyTrainer(BaseTrainer):
 
 def make_trainer():
     model = DummyModel()
+    opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
+    return DummyTrainer(model, opt, train_loader=[], device="cpu")
+
+
+def make_continuous_trainer():
+    model = DummyContinuousModel()
     opt = torch.optim.SGD([torch.zeros(1, requires_grad=True)], lr=0.1)
     return DummyTrainer(model, opt, train_loader=[], device="cpu")
 
@@ -115,4 +132,51 @@ def test_outcome_metrics():
     metrics = trainer._outcome_metrics(x, y, torch.tensor([-1, -1]))
     assert metrics["rmse_unlabelled"] == pytest.approx(0.0)
     assert metrics["rmse"] == pytest.approx(0.0)
+
+
+def test_extract_batch_continuous_model():
+    trainer = make_continuous_trainer()
+    x = torch.randn(2, 1)
+    y = torch.randn(2, 1)
+    _, _, t_obs = trainer._extract_batch((x, y))
+    assert t_obs.dtype == torch.float32
+
+
+def test_extract_batch_gnn_scm():
+    model = GNN_SCM(d_x=2, d_y=1, k=None)
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = DummyTrainer(model, opt, train_loader=[], device="cpu")
+    x = torch.randn(2, 2)
+    y = torch.randn(2, 1)
+    _, _, t_obs = trainer._extract_batch((x, y))
+    assert t_obs.dtype == torch.float32
+
+
+def test_treatment_metrics_continuous():
+    trainer = make_continuous_trainer()
+    x = torch.zeros(2, 1)
+    y = torch.zeros(2, 1)
+    t_obs = torch.tensor([0.1, 0.2])
+    metrics = trainer._treatment_metrics(x, y, t_obs)
+    assert metrics == {}
+
+
+class DummyHeadModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.k = None
+        self.head_Y = torch.nn.Linear(3, 1, bias=False)
+        with torch.no_grad():
+            self.head_Y.weight.copy_(torch.tensor([[1.0, 2.0, 3.0]]))
+
+
+def test_predict_outcome_with_float_treatment():
+    model = DummyHeadModel()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    trainer = DummyTrainer(model, opt, train_loader=[], device="cpu")
+    x = torch.tensor([[1.0, 2.0]])
+    t = torch.tensor([0.5])
+    y = torch.zeros(1, 1)
+    out = trainer._predict_outcome(x, t, y)
+    assert out.item() == pytest.approx(6.5)
 


### PR DESCRIPTION
## Summary
- handle continuous treatments in `_extract_batch`
- skip treatment NLL/accuracy when `k=None`
- support continuous `t` in `_predict_outcome`
- add unit tests covering continuous treatment scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885443b2788324b6d691c48e37f4ec