### PR TITLE
Support continuous treatments in active strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,13 @@ Utilities in :mod:`xtylearner.active` implement common query strategies for
 selecting the most informative unlabelled points:
 
 - ``EntropyT`` – rank samples by the entropy of the model's treatment
-  predictions.
+  predictions.  When ``model.k`` is ``None`` (continuous treatments) the
+  strategy uses the variance of ``log p(t\mid x)`` estimated from Monte Carlo
+  samples instead.
 - ``DeltaCATE`` – prioritise points with high variance in predicted treatment
-  effects.
-- ``FCCMRadius`` – a weighted combination of entropy, effect variance and the
+  effects.  For continuous treatments it draws multiple treatment samples
+  directly without one-hot encoding.
+- ``FCCMRadius`` – a weighted combination of these uncertainty scores and the
   coverage radius around labelled data.
 
 The :class:`xtylearner.training.ActiveTrainer` wraps a standard trainer with an
@@ -253,3 +256,6 @@ xtylearner-train --model m2_vae --dataset toy
 This command loads the default configuration from
 ``xtylearner/configs/default.yaml``.  A custom YAML config file may be supplied
 with ``--config`` to override any settings.
+The repository also provides ``configs/continuous.yaml`` as an example
+training setup for :class:`~xtylearner.models.GNN_SCM` with continuous
+treatments and active learning.

--- a/configs/continuous.yaml
+++ b/configs/continuous.yaml
@@ -1,0 +1,27 @@
+# Example configuration for continuous treatments with ActiveTrainer
+
+dataset:
+  name: tabular
+  params:
+    data: path/to/data.csv
+    outcome_col: outcome
+    treatment_col: treatment
+
+model:
+  name: gnn_scm
+  params:
+    d_x: 4
+    d_y: 1
+    k: null
+
+training:
+  trainer: ActiveTrainer
+  batch_size: 32
+  learning_rate: 0.001
+  epochs: 5
+
+active:
+  strategy: fccm
+  budget: 20
+  batch: 5
+  lambdas: [0.5, 0.3, 0.2]


### PR DESCRIPTION
## Summary
- adapt EntropyT, DeltaCATE and FCCMRadius for continuous treatments
- add example configuration demonstrating active learning with continuous treatments
- document new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885444f6ec83249380776a62add3bf