### PR TITLE
Support continuous treatment in GNN_SCM

### DIFF
--- a/docs/novel/gnn_scm.md
+++ b/docs/novel/gnn_scm.md
@@ -18,6 +18,8 @@ simpler graphs.
 * `lambda_acyc` controls the strength of the acyclicity penalty.
 * `gamma_l1` sets the L1 regularisation weight on the adjacency matrix.
 * Set `forbid_y_to_x=True` (default) to exclude edges from `Y` to any `X_i`.
+* Use `predict_treatment_params` to obtain either discrete probabilities or
+  the mean and variance of the continuous treatment distribution.
 
 ## References
 

--- a/tests/generative/test_gnn_scm.py
+++ b/tests/generative/test_gnn_scm.py
@@ -19,3 +19,17 @@ def test_gnn_scm_learns_acyclic():
     final_acyc = float((torch.trace(torch.matrix_exp(A * A)) - A.size(0)))
     assert final_acyc <= init_acyc
     assert final_acyc < 1.0
+
+
+def test_gnn_scm_continuous_treatment():
+    ds = load_toy_dataset(n_samples=30, d_x=2, seed=5, continuous=True)
+    loader = DataLoader(ds, batch_size=10)
+    model = GNN_SCM(d_x=2, d_y=1, k=None)
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    trainer = Trainer(model, opt, loader)
+    trainer.fit(1)
+
+    X, _, _ = ds.tensors
+    params = model.predict_treatment_params(X)
+    assert params.shape == (30, 2)
+    assert (params[:, 1] > 0).all()

--- a/xtylearner/data/toy_dataset.py
+++ b/xtylearner/data/toy_dataset.py
@@ -19,6 +19,8 @@ def load_toy_dataset(
     n_samples: int = 100,
     d_x: int = 2,
     seed: int = 0,
+    *,
+    continuous: bool = False,
 ) -> TensorDataset:
     """Generate a tiny synthetic dataset for quick experiments.
 
@@ -30,17 +32,25 @@ def load_toy_dataset(
         Dimensionality of the covariates.
     seed:
         Random seed used for reproducibility.
+    continuous:
+        If ``True``, generate continuous treatments instead of binary labels.
 
     Returns
     -------
     TensorDataset
         Dataset of shape ``(n_samples, d_x)``, outcome vector ``Y`` and
-        binary treatment ``T``.
+        treatment ``T``.  ``T`` is binary by default or continuous when
+        ``continuous=True``.
     """
 
     rng = np.random.default_rng(seed)
     X = rng.normal(size=(n_samples, d_x)).astype(np.float32)
-    T = rng.integers(0, 2, size=n_samples).astype(np.int64)
+    if continuous:
+        w_t = rng.normal(size=d_x)
+        T = X @ w_t + rng.normal(scale=0.1, size=n_samples)
+        T = T.astype(np.float32)
+    else:
+        T = rng.integers(0, 2, size=n_samples).astype(np.int64)
 
     beta = rng.normal(size=d_x)
     Y = X @ beta + 0.5 * T + rng.normal(scale=0.1, size=n_samples)


### PR DESCRIPTION
## Summary
- allow continuous treatments in `load_toy_dataset`
- add `predict_treatment_params` method in `GNN_SCM`
- handle scalar/1D treatments in `GNN_SCM` internals
- document treatment parameter prediction
- test continuous treatment training

## Testing
- `pre-commit run --files xtylearner/models/gnn_scm.py tests/generative/test_gnn_scm.py xtylearner/data/toy_dataset.py docs/novel/gnn_scm.md`
- `pytest -k gnn_scm -vv`

------
https://chatgpt.com/codex/tasks/task_e_6888544e30d08324b4fd404aab02f99f