### PR TITLE
Add column-masking JEPA model

### DIFF
--- a/tests/models/test_tab_jepa.py
+++ b/tests/models/test_tab_jepa.py
@@ -1,0 +1,12 @@
+from xtylearner.data import load_synthetic_dataset
+from xtylearner.models import TabJEPA
+
+
+def test_tab_jepa_loss_and_forward():
+    ds = load_synthetic_dataset(n_samples=10, d_x=2, seed=0)
+    X, Y, T = ds.tensors
+    model = TabJEPA(d_x=2, d_y=1, k=2)
+    loss = model.loss(X, Y, T)
+    assert loss.dim() == 0
+    out = model.predict_outcome(X, T)
+    assert out.shape == (10, 1)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,7 +1,8 @@
 import pytest
+import torch
 import torch.nn as nn
 
-from xtylearner.models.layers import make_mlp
+from xtylearner.models.layers import make_mlp, ColumnEmbedder, apply_column_mask
 
 
 def test_make_mlp_default():
@@ -33,3 +34,16 @@ def test_make_mlp_dropout_sequence():
 def test_make_mlp_dropout_mismatch():
     with pytest.raises(ValueError):
         make_mlp([2, 3, 1], dropout=[0.1, 0.2])
+
+
+def test_column_embedder_and_mask():
+    emb = ColumnEmbedder(d_x=2, d_y=1, k=2, d_embed=4)
+    X = torch.randn(3, 2)
+    T = torch.tensor([0, 1, 0])
+    T_tok = torch.nn.functional.one_hot(T, 2).float()
+    toks = emb(X, T_tok)
+    assert toks.shape == (3, 3, 4)
+
+    masked, mask = apply_column_mask(toks, 0.5)
+    assert masked.shape == toks.shape
+    assert mask.shape == (3, 3)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -32,6 +32,7 @@ from xtylearner.models import (
     CTMT,
     SCGM,
     CCL_CPCModel,
+    TabJEPA,
 )
 
 
@@ -70,6 +71,7 @@ from xtylearner.models import (
         ("ctm_t", CTMT, {"d_in": 4}),
         ("scgm", SCGM, {"d_x": 2, "d_y": 1, "k": 2}),
         ("ccl_cpc", CCL_CPCModel, {"d_x": 2, "d_y": 1, "k": 2}),
+        ("tab_jepa", TabJEPA, {"d_x": 2, "d_y": 1, "k": 2}),
     ],
 )
 def test_get_model_valid(name, cls, kwargs):

--- a/xtylearner/models/__init__.py
+++ b/xtylearner/models/__init__.py
@@ -19,6 +19,7 @@ from .dragon_net import DragonNet
 from .cacore_model import CaCoRE
 from .gnn_scm import GNN_SCM
 from .diffusion_gnn_scm import DiffusionGNN_SCM
+from .tab_jepa import TabJEPA
 from .em_model import EMModel
 from .labelprop import LP_KNN
 from .mean_teacher import MeanTeacher
@@ -73,6 +74,7 @@ __all__ = [
     "SemiITE",
     "CTMT",
     "SCGM",
+    "TabJEPA",
     "get_model",
     "get_model_names",
     "get_model_args",

--- a/xtylearner/models/tab_jepa.py
+++ b/xtylearner/models/tab_jepa.py
@@ -1,0 +1,153 @@
+# Bacharach et al. "I-JEPA: Moving Self-Supervised Learning Beyond Pixels" • ICCV 2023
+
+import copy
+import torch
+import torch.nn as nn
+from torch.nn.functional import one_hot
+
+from .layers import ColumnEmbedder, apply_column_mask
+from .heads import LowRankDiagHead
+from ..losses import nll_lowrank_diag
+from ..training.metrics import mse_loss
+
+from .registry import register_model
+
+
+@register_model("tab_jepa")
+class TabJEPA(nn.Module):
+    """Tabular Joint-Embedding Predictive Architecture.
+
+    Pre-trains by masking column tokens of ``(X, T, Y)`` and predicting the
+    latent representation of the unmasked sequence.
+    During fine-tuning ``forward`` returns outcome predictions from the
+    aggregated representation.
+    """
+
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int,
+        k: int | None = None,
+        *,
+        d_embed: int = 64,
+        depth: int = 4,
+        mask_ratio: float = 0.4,
+        momentum: float = 0.996,
+        lowrank_head: bool = False,
+        rank: int = 4,
+    ) -> None:
+        super().__init__()
+        self.k = k
+        self.mask_ratio = mask_ratio
+        self.momentum = momentum
+        self.lowrank_head = lowrank_head
+
+        # column tokeniser
+        self.embed = ColumnEmbedder(d_x, d_y, k, d_embed)
+
+        # encoders
+        self.encoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_embed, nhead=8, dim_feedforward=4 * d_embed),
+            num_layers=depth,
+        )
+        self.target_encoder = copy.deepcopy(self.encoder)
+        for p in self.target_encoder.parameters():
+            p.requires_grad_(False)
+
+        # predictor head
+        self.predictor = nn.Sequential(
+            nn.Linear(d_embed, d_embed), nn.ReLU(), nn.Linear(d_embed, d_embed)
+        )
+
+        # downstream Y head
+        if lowrank_head:
+            self.Y_head = LowRankDiagHead(d_embed, d_y, rank)
+        else:
+            self.Y_head = nn.Linear(d_embed, d_y)
+
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def _momentum_update(self) -> None:
+        """Update target encoder with exponential moving average."""
+
+        for q, k in zip(self.target_encoder.parameters(), self.encoder.parameters()):
+            q.data.mul_(self.momentum).add_(k.data, alpha=1.0 - self.momentum)
+
+    # ------------------------------------------------------------------
+    def forward(self, X: torch.Tensor, T: torch.Tensor):
+        """Predict outcomes from covariates and treatments."""
+
+        if self.k is None:
+            T_tok = T.unsqueeze(-1).float()
+        else:
+            T_tok = one_hot(T.to(torch.long), self.k).float()
+        tokens = self.embed(X, T_tok)
+        h = self.encoder(tokens).mean(1)
+        if self.lowrank_head:
+            mu, F, sigma2 = self.Y_head(h)
+            return mu, F, sigma2
+        else:
+            return self.Y_head(h)
+
+    @torch.no_grad()
+    def predict_outcome(self, X: torch.Tensor, T: torch.Tensor):
+        out = self.forward(X, T)
+        return out[0] if self.lowrank_head else out
+
+    # ------------------------------------------------------------------
+    def loss(
+        self,
+        X: torch.Tensor,
+        Y: torch.Tensor,
+        T_obs: torch.Tensor,
+        *,
+        λ_jepa: float = 1.0,
+        λ_sup: float = 1.0,
+    ) -> torch.Tensor:
+        """Blend JEPA pre-text loss with supervised outcome loss."""
+
+        if self.k is None:
+            T_tok = T_obs.unsqueeze(-1).float()
+        else:
+            T_tok = one_hot(T_obs.clamp(min=0).to(torch.long), self.k).float()
+
+        # construct token sequence
+        full_tokens = self.embed(X, T_tok)
+
+        # apply column mask
+        masked_tokens, mask = apply_column_mask(full_tokens, self.mask_ratio)
+
+        # encoders
+        h_ctx = self.encoder(masked_tokens)
+        with torch.no_grad():
+            h_tgt = self.target_encoder(full_tokens)
+
+        # JEPA loss
+        pred = self.predictor(h_ctx[mask])
+        target = h_tgt[mask]
+        L_jepa = (pred - target).pow(2).mean()
+
+        self._momentum_update()
+
+        # supervised loss on labelled rows
+        labelled = T_obs >= 0
+        if labelled.any():
+            Y_hat = self.predict_outcome(X[labelled], T_obs[labelled])
+            if self.lowrank_head:
+                mu, F, sigma2 = Y_hat
+                L_sup = nll_lowrank_diag(Y[labelled], mu, F, sigma2).mean()
+            else:
+                L_sup = mse_loss(Y_hat, Y[labelled])
+        else:
+            L_sup = 0.0
+
+        return λ_jepa * L_jepa + λ_sup * L_sup
+
+    # ------------------------------------------------------------------
+    def predict_treatment_proba(self, X: torch.Tensor, Y: torch.Tensor):
+        if self.k is None:
+            return torch.full((X.size(0),), float("nan"), device=X.device)
+        return torch.full((X.size(0), self.k), 1 / self.k, device=X.device)
+
+
+__all__ = ["TabJEPA"]


### PR DESCRIPTION
## Summary
- implement `TabJEPA` model for self-supervised column masking
- expose utilities `ColumnEmbedder` and `apply_column_mask`
- register the model in package exports and update tests
- add tests for new helpers and model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3b82606883248f9db8e4070ce9d2