### PR TITLE
Add IHDP dataset to run_benchmark

### DIFF
--- a/examples/benchmark_models.py
+++ b/examples/benchmark_models.py
@@ -1,4 +1,4 @@
-"""Benchmark all registered models on built-in synthetic datasets."""
+"""Benchmark all registered models on built-in datasets."""
 
 import os
 import pandas as pd
@@ -33,8 +33,10 @@ def _run_single(task):
     torch.set_num_threads(1)
     if ds_name == "synthetic_mixed":
         full_ds = get_dataset(ds_name, n_samples=100, d_x=2, label_ratio=0.5, seed=0)
-    else:
+    elif ds_name == "synthetic":
         full_ds = get_dataset(ds_name, n_samples=100, d_x=2, seed=0)
+    else:
+        full_ds = get_dataset(ds_name)
     half = len(full_ds) // 2
     ds = TensorDataset(*(t[:half] for t in full_ds.tensors))
     val_ds = TensorDataset(*(t[half:] for t in full_ds.tensors))
@@ -68,7 +70,7 @@ def run_benchmark(output_path: str = "benchmark_results.md") -> None:
     Results are written as separate tables for each dataset in the
     provided Markdown file.
     """
-    dataset_names = ["synthetic", "synthetic_mixed"]
+    dataset_names = ["synthetic", "synthetic_mixed", "ihdp"]
     tasks = [
         (ds_name, model_name)
         for ds_name in dataset_names


### PR DESCRIPTION
## Summary
- include IHDP dataset in benchmark models evaluation
- handle dataset-specific loading without synthetic defaults

## Testing
- `pre-commit run --files examples/benchmark_models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ae78b048832492dc23771c6ad623