### PR TITLE
Run ASV benchmarks from labeled pull_request_target

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,20 +1,21 @@
 name: Benchmark Models
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   benchmark:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'run-asv')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -65,7 +66,7 @@ jobs:
           git add .asv/results
           if ! git diff --cached --quiet; then
             git commit -m "Update ASV benchmark results"
-            git push origin HEAD:${{ github.head_ref }}
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run benchmarks workflow on `pull_request_target` when PR is labeled `run-asv`
- checkout fork head with write token so CI can commit `.asv/results`

## Testing
- `pre-commit run --files .github/workflows/benchmark.yml`

------
https://chatgpt.com/codex/tasks/task_e_68aaa426cee0832492217e5e21547933