### PR TITLE
Reduce benchmark learning rate and disable CycleVAT likelihood by default

### DIFF
--- a/examples/benchmark_models.py
+++ b/examples/benchmark_models.py
@@ -16,12 +16,12 @@ def _make_optimizer(model: torch.nn.Module) -> torch.optim.Optimizer:
     params = [p for p in getattr(model, "parameters", lambda: [])() if p.requires_grad]
     if not params:
         params = [torch.zeros(1, requires_grad=True)]
-    return torch.optim.Adam(params, lr=0.01)
+    return torch.optim.Adam(params, lr=0.001)
 
 
 def _make_gan_optimizer(model: torch.nn.Module):
-    opt_g = torch.optim.Adam(model.parameters(), lr=0.01)
-    opt_d = torch.optim.Adam(model.parameters(), lr=0.01)
+    opt_g = torch.optim.Adam(model.parameters(), lr=0.001)
+    opt_d = torch.optim.Adam(model.parameters(), lr=0.001)
     return opt_g, opt_d
 
 

--- a/xtylearner/models/cycle_vat.py
+++ b/xtylearner/models/cycle_vat.py
@@ -47,7 +47,7 @@ class CycleVAT(nn.Module):
         norm_layer: callable | None = None,
         residual: bool = False,
         # outcome head
-        outcome_likelihood: bool = True,
+        outcome_likelihood: bool = False,
         outcome_rank: int = 8,
         # y encoder for inverse classifier
         y_embed_dims: tuple[int, ...] | list[int] | None = (64,),


### PR DESCRIPTION
## Summary
- Use a standard Adam learning rate of 1e-3 in benchmark optimizer helpers
- Disable low-rank Gaussian outcome head by default in `CycleVAT`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac1c6b96c48324afd0d696c6f67e27