### PR TITLE
Add uncertainty-based loss weighting to DragonNet

### DIFF
--- a/xtylearner/models/dragon_net.py
+++ b/xtylearner/models/dragon_net.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 from .layers import make_mlp
 from .registry import register_model
+from .utils import UncertaintyWeighter
 
 
 @register_model("dragon_net")
@@ -14,7 +15,16 @@ class DragonNet(nn.Module):
     term for doubly robust effect estimates.
     """
 
-    def __init__(self, d_x: int, d_y: int = 1, k: int = 2, h: int = 200, *, lmbda=(1.0, 1.0, 1.0, 1.0)) -> None:
+    def __init__(
+        self,
+        d_x: int,
+        d_y: int = 1,
+        k: int = 2,
+        h: int = 200,
+        *,
+        lmbda: tuple[float, float, float, float] | None = None,
+        init_log_vars: float = 0.0,
+    ) -> None:
         super().__init__()
         self.k = k
         self.encoder = make_mlp([d_x, h, h, h], activation=nn.ReLU)
@@ -23,6 +33,10 @@ class DragonNet(nn.Module):
         self.recon_head = nn.Linear(h + d_y, k)
         self.lmbda = lmbda
         self.d_y = d_y
+        if lmbda is None:
+            self.loss_weighter = UncertaintyWeighter(num_tasks=5, init_log_vars=init_log_vars)
+        else:
+            self.loss_weighter = None
 
     # ------------------------------------------------------------------
     def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
@@ -72,6 +86,9 @@ class DragonNet(nn.Module):
                 * (y_lab.unsqueeze(1) - mu_lab)
             ).mean(0)
             tar_reg = tau_dr.pow(2).sum()
+
+        if self.loss_weighter is not None:
+            return self.loss_weighter([mse_y, ce_pi, ce_rho, kl, tar_reg])
 
         l1, l2, l3, l4 = self.lmbda
         return mse_y + l1 * ce_pi + l2 * ce_rho + l3 * kl + l4 * tar_reg

--- a/xtylearner/models/dragon_net.py
+++ b/xtylearner/models/dragon_net.py
@@ -88,7 +88,11 @@ class DragonNet(nn.Module):
             tar_reg = tau_dr.pow(2).sum()
 
         if self.loss_weighter is not None:
-            return self.loss_weighter([mse_y, ce_pi, ce_rho, kl, tar_reg])
+            losses = [mse_y, ce_pi, ce_rho, kl, tar_reg]
+            mask = [L.requires_grad for L in losses]
+            if any(mask):
+                return self.loss_weighter(losses, mask=mask)
+            return torch.tensor(0.0, device=x.device)
 
         l1, l2, l3, l4 = self.lmbda
         return mse_y + l1 * ce_pi + l2 * ce_rho + l3 * kl + l4 * tar_reg

--- a/xtylearner/models/utils.py
+++ b/xtylearner/models/utils.py
@@ -193,11 +193,37 @@ class UncertaintyWeighter(nn.Module):
         super().__init__()
         self.log_vars = nn.Parameter(torch.full((num_tasks,), float(init_log_vars)))
 
-    def forward(self, losses: list[torch.Tensor] | tuple[torch.Tensor, ...]) -> torch.Tensor:
-        assert len(losses) == self.log_vars.numel()
-        s = self.log_vars
+    def forward(
+        self,
+        losses: list[torch.Tensor] | tuple[torch.Tensor, ...],
+        mask: list[bool] | tuple[bool, ...] | None = None,
+    ) -> torch.Tensor:
+        """Return the weighted sum of ``losses``.
+
+        Parameters
+        ----------
+        losses:
+            Sequence of per-task losses.
+        mask:
+            Optional boolean mask with ``len(mask) == num_tasks`` indicating
+            which losses are active for the current batch. Inactive tasks are
+            ignored and receive no ``log_var`` penalty.
+        """
+
+        losses = list(losses)
+        if mask is None:
+            assert len(losses) == self.log_vars.numel()
+            s = self.log_vars
+            weights = torch.exp(-s)
+            total = sum(w * L for w, L in zip(weights, losses)) + torch.sum(s)
+            return total
+
+        mask_tensor = torch.as_tensor(mask, dtype=torch.bool, device=self.log_vars.device)
+        assert mask_tensor.numel() == self.log_vars.numel()
+        active_losses = [L for L, m in zip(losses, mask) if m]
+        s = self.log_vars[mask_tensor]
         weights = torch.exp(-s)
-        total = sum(w * L for w, L in zip(weights, losses)) + torch.sum(s)
+        total = sum(w * L for w, L in zip(weights, active_losses)) + torch.sum(s)
         return total
 
     def weights(self) -> list[float]:


### PR DESCRIPTION
## Summary
- add generic `UncertaintyWeighter` module for task-uncertainty loss scaling
- integrate uncertainty-based weighting into DragonNet for adaptive balancing of loss terms

## Testing
- `ruff check xtylearner/models/dragon_net.py xtylearner/models/utils.py`
- `pytest tests/test_trainer.py::test_dragon_net_runs tests/test_trainer.py::test_dragon_net_multi_outcome tests/test_registry.py::test_get_model_valid[dragon_net-DragonNet-kwargs9] -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6031bc5a88324bbc8ee1c1ad31860