### PR TITLE
Fix ASV data generation by disabling parallel execution

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,9 +42,9 @@ jobs:
               echo "Will benchmark models: $MODELS,jsbf,eg_ddi,cevae_m"
             fi
           else
-            # Full benchmark on main branch pushes
-            echo "strategy=parallel" >> $GITHUB_OUTPUT
-            echo "models=" >> $GITHUB_OUTPUT
+            # Full benchmark on main branch pushes - use core models for now to debug
+            echo "strategy=core" >> $GITHUB_OUTPUT
+            echo "models=jsbf,eg_ddi,cevae_m" >> $GITHUB_OUTPUT
             echo "should_run=true" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Switch main branch pushes from parallel to core strategy to debug why no benchmark results are being generated. The parallel mode was using temporary directories but the merge step wasn't working, leaving no actual benchmark data in the results directory.

This will allow ASV to generate proper benchmark data and fix the "No benchmark data available" issue on the website.

🤖 Generated with [Claude Code](https://claude.ai/code)