### PR TITLE
Update benchmark results to include expanded model set

### DIFF
--- a/.asv/results/benchmarks.json
+++ b/.asv/results/benchmarks.json
@@ -12,13 +12,17 @@
                 "'synthetic_mixed'"
             ],
             [
-                "'cycle_dual'"
+                "'cycle_dual'",
+                "'mean_teacher'",
+                "'prob_circuit'",
+                "'ganite'",
+                "'flow_ssc'"
             ]
         ],
         "timeout": 600,
         "type": "track",
         "unit": "unit",
-        "version": "d429049ca0ef91db7c7e97d0a24660ed6ee9c9f8da60f6d6795876b5f4b192e9"
+        "version": "cd6f3d1dfef8d3bed2d01a328d15d21d92d008bfc6b0c3badb384ea1df5c841b"
     },
     "version": 2
 }


### PR DESCRIPTION
Expanded benchmark parameters to include all 5 default models:
- cycle_dual
- mean_teacher
- prob_circuit
- ganite
- flow_ssc

This aligns the ASV results file with the GitHub Actions workflow configuration that runs benchmarks on these models by default.

🤖 Generated with [Claude Code](https://claude.ai/code)