### PR TITLE
Fix GANITE optimizer setup in benchmarks

### DIFF
--- a/tests/test_benchmark_eval.py
+++ b/tests/test_benchmark_eval.py
@@ -1,0 +1,37 @@
+import torch
+
+from eval import BenchmarkDataBundle, ModelBenchmarker
+
+
+def test_benchmarker_builds_ganite_optimizers():
+    benchmarker = ModelBenchmarker()
+    bundle = BenchmarkDataBundle(
+        train_loader=None,
+        val_loader=None,
+        x_dim=2,
+        y_dim=1,
+    )
+
+    model, optimizers = benchmarker._build_model_components("ganite", bundle)
+
+    assert isinstance(optimizers, tuple)
+    assert len(optimizers) == 2
+
+    opt_g, opt_d = optimizers
+    assert isinstance(opt_g, torch.optim.Optimizer)
+    assert isinstance(opt_d, torch.optim.Optimizer)
+
+    params_g = {
+        id(param)
+        for group in opt_g.param_groups
+        for param in group["params"]
+    }
+    params_d = {
+        id(param)
+        for group in opt_d.param_groups
+        for param in group["params"]
+    }
+
+    assert params_g, "generator optimizer should manage parameters"
+    assert params_d, "discriminator optimizer should manage parameters"
+    assert params_g.isdisjoint(params_d), "G/D optimizers must not share params"

--- a/xtylearner/models/ganite.py
+++ b/xtylearner/models/ganite.py
@@ -142,5 +142,19 @@ class GANITE(nn.Module):
         logits = self.C_t(z)
         return logits.softmax(-1)
 
+    # --------------------------------------------------------------
+    def generator_parameters(self):
+        """Yield parameters optimised by the generator step."""
+
+        yield from self.G_cf.parameters()
+        yield from self.G_ite.parameters()
+        yield from self.C_t.parameters()
+
+    # --------------------------------------------------------------
+    def discriminator_parameters(self):
+        """Yield parameters optimised by the discriminator step."""
+
+        yield from self.D_y.parameters()
+
 
 __all__ = ["GANITE"]


### PR DESCRIPTION
## Summary
- teach GANITE to expose generator and discriminator parameter iterators
- update the benchmarker's model factory to build separate optimisers for adversarial models
- add a regression test to ensure GANITE optimisers built by the benchmarker remain disjoint

## Testing
- pytest tests/test_benchmark_eval.py tests/test_trainer.py::test_ganite_trainer_runs

------
https://chatgpt.com/codex/tasks/task_e_68d3cec9b2a08324a13f6696eb32f94a