### PR TITLE
Add criteo_uplift to GitHub Actions benchmark testing

### DIFF
--- a/benchmark_config.json
+++ b/benchmark_config.json
@@ -4,7 +4,7 @@
   "confidence_level": 0.95,
   "metrics": ["val_outcome_rmse", "val_treatment_accuracy", "train_time_seconds"],
   "models": ["cycle_dual", "mean_teacher", "prob_circuit", "ganite", "flow_ssc"],
-  "datasets": ["synthetic", "synthetic_mixed"],
+  "datasets": ["synthetic", "synthetic_mixed", "criteo_uplift"],
   "statistical_method": "bootstrap",
   "training_epochs": 10,
   "sample_size": 100,

--- a/eval.py
+++ b/eval.py
@@ -85,20 +85,27 @@ class ModelBenchmarker:
         if cache_key in self._data_cache:
             return self._data_cache[cache_key]
 
-        dataset_kwargs: Dict[str, Any] = {
-            "n_samples": self.config["sample_size"],
-            "d_x": 2,
-        }
+        dataset_kwargs: Dict[str, Any] = {"n_samples": self.config["sample_size"]}
+
+        # Add dataset-specific parameters
+        if dataset_name in ["synthetic", "synthetic_mixed"]:
+            dataset_kwargs["d_x"] = 2
         if dataset_name == "synthetic_mixed":
             dataset_kwargs.update({"label_ratio": 0.5})
+        elif dataset_name == "criteo_uplift":
+            dataset_kwargs.update({"prefer_real": False, "seed": 42})
 
         cache_params = {
             "dataset": dataset_name,
             "n_samples": dataset_kwargs["n_samples"],
-            "d_x": dataset_kwargs["d_x"],
         }
+        if "d_x" in dataset_kwargs:
+            cache_params["d_x"] = dataset_kwargs["d_x"]
         if dataset_name == "synthetic_mixed":
             cache_params["label_ratio"] = dataset_kwargs["label_ratio"]
+        elif dataset_name == "criteo_uplift":
+            cache_params["prefer_real"] = dataset_kwargs["prefer_real"]
+            cache_params["seed"] = dataset_kwargs["seed"]
 
         cache_hash = hashlib.sha1(json.dumps(cache_params, sort_keys=True).encode()).hexdigest()[:12]
         dataset_cache_dir = self._cache_dir / "datasets"

--- a/scripts/generate_benchmark_matrix.py
+++ b/scripts/generate_benchmark_matrix.py
@@ -17,7 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 
 PR_MATRIX = {
     "model": ["cycle_dual", "mean_teacher"],
-    "dataset": ["synthetic"],
+    "dataset": ["synthetic", "criteo_uplift"],
 }
 
 FULL_MATRIX = {
@@ -43,7 +43,7 @@ FULL_MATRIX = {
         "vacim",
         "multitask",
     ],
-    "dataset": ["synthetic", "synthetic_mixed"],
+    "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift"],
 }
 
 DEFAULT_MATRIX = {
@@ -61,7 +61,7 @@ DEFAULT_MATRIX = {
         "cacore",
         "ss_cevae",
     ],
-    "dataset": ["synthetic", "synthetic_mixed"],
+    "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift"],
 }
 
 
@@ -139,7 +139,7 @@ def choose_matrix(
     models.update(files_to_models(changed_model_files))
 
     if models:
-        return {"model": sorted(models), "dataset": ["synthetic", "synthetic_mixed"]}
+        return {"model": sorted(models), "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift"]}
     if event_name == "pull_request":
         return PR_MATRIX
     if full_benchmark:


### PR DESCRIPTION
- Include criteo_uplift in all benchmark matrices (PR, default, full)
- Fix eval.py to handle Criteo dataset parameters correctly
- Add Criteo to default benchmark config
- Enable CI testing of bundled Criteo sample dataset

Now the Criteo uplift dataset will be tested in GitHub Actions alongside synthetic datasets, providing formal benchmark validation.

🤖 Generated with [Claude Code](https://claude.ai/code)