### PR TITLE
Add NHEFS dataset to GitHub Actions benchmark testing

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -94,6 +94,8 @@ class ModelBenchmarker:
             dataset_kwargs.update({"label_ratio": 0.5})
         elif dataset_name == "criteo_uplift":
             dataset_kwargs.update({"prefer_real": False, "seed": 42})
+        elif dataset_name == "nhefs":
+            dataset_kwargs.update({"seed": 42})
 
         cache_params = {
             "dataset": dataset_name,
@@ -105,6 +107,8 @@ class ModelBenchmarker:
             cache_params["label_ratio"] = dataset_kwargs["label_ratio"]
         elif dataset_name == "criteo_uplift":
             cache_params["prefer_real"] = dataset_kwargs["prefer_real"]
+            cache_params["seed"] = dataset_kwargs["seed"]
+        elif dataset_name == "nhefs":
             cache_params["seed"] = dataset_kwargs["seed"]
 
         cache_hash = hashlib.sha1(json.dumps(cache_params, sort_keys=True).encode()).hexdigest()[:12]

--- a/scripts/generate_benchmark_matrix.py
+++ b/scripts/generate_benchmark_matrix.py
@@ -17,7 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 
 PR_MATRIX = {
     "model": ["cycle_dual", "mean_teacher"],
-    "dataset": ["synthetic", "criteo_uplift"],
+    "dataset": ["synthetic", "criteo_uplift", "nhefs"],
 }
 
 FULL_MATRIX = {
@@ -43,7 +43,7 @@ FULL_MATRIX = {
         "vacim",
         "multitask",
     ],
-    "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift"],
+    "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift", "nhefs"],
 }
 
 DEFAULT_MATRIX = {
@@ -61,7 +61,7 @@ DEFAULT_MATRIX = {
         "cacore",
         "ss_cevae",
     ],
-    "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift"],
+    "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift", "nhefs"],
 }
 
 
@@ -139,7 +139,7 @@ def choose_matrix(
     models.update(files_to_models(changed_model_files))
 
     if models:
-        return {"model": sorted(models), "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift"]}
+        return {"model": sorted(models), "dataset": ["synthetic", "synthetic_mixed", "criteo_uplift", "nhefs"]}
     if event_name == "pull_request":
         return PR_MATRIX
     if full_benchmark:


### PR DESCRIPTION
- Include nhefs in all benchmark matrices (PR, default, full)
- Add NHEFS dataset parameter support in eval.py
- Enable CI testing of NHEFS dataset alongside other datasets

Now GitHub Actions will test all available datasets: synthetic, synthetic_mixed, criteo_uplift, and nhefs for comprehensive causal inference benchmark validation.

🤖 Generated with [Claude Code](https://claude.ai/code)