### PR TITLE
Stabilize flow_ssc training across benchmarks

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -253,6 +253,7 @@ class ModelBenchmarker:
             model_kwargs = {"d_in": data_bundle.x_dim + data_bundle.y_dim + 1}
 
         model = get_model(model_name, **model_kwargs)
+        lr = getattr(model, "default_lr", 0.001)
 
         if hasattr(model, "loss_G") and hasattr(model, "loss_D"):
             gen_params: List[torch.nn.Parameter] = []
@@ -296,8 +297,8 @@ class ModelBenchmarker:
                 ]
 
             optimizer = (
-                torch.optim.Adam(gen_params, lr=0.001),
-                torch.optim.Adam(disc_params, lr=0.001),
+                torch.optim.Adam(gen_params, lr=lr),
+                torch.optim.Adam(disc_params, lr=lr),
             )
         else:
             params = [
@@ -307,7 +308,7 @@ class ModelBenchmarker:
             ]
             if not params:
                 params = [torch.zeros(1, requires_grad=True)]
-            optimizer = torch.optim.Adam(params, lr=0.001)
+            optimizer = torch.optim.Adam(params, lr=lr)
 
         return model, optimizer
 

--- a/xtylearner/training/trainer.py
+++ b/xtylearner/training/trainer.py
@@ -67,6 +67,8 @@ class Trainer:
         """
 
         trainer_cls = self._select_trainer(model)
+        if grad_clip_norm is None:
+            grad_clip_norm = getattr(model, "grad_clip_norm", None)
         if trainer_cls is AdversarialTrainer:
             if not isinstance(optimizer, (tuple, list)) or len(optimizer) != 2:
                 raise ValueError("AdversarialTrainer requires two optimizers")


### PR DESCRIPTION
## Summary
- add internal normalisation, bounded coupling transforms, and log-likelihood clamping to `flow_ssc` so the flow remains stable on high-variance benchmarks
- allow models to surface a default learning rate and gradient clipping setting that the trainer/benchmarker now honour
- cap predicted outcomes to prevent RMSE from exploding when the flow drifts during evaluation

## Testing
- python eval.py --model flow_ssc --dataset nhefs
- python eval.py --model flow_ssc --dataset synthetic
- python eval.py --model flow_ssc --dataset synthetic_mixed

------
https://chatgpt.com/codex/tasks/task_e_68d7292df5508324a5d2da018df88f94