### PR TITLE
Scale NHEFS covariates before benchmarking

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -350,6 +350,14 @@ class ModelBenchmarker:
             trainer.fit(self.config["training_epochs"])
             train_time = time.perf_counter() - start_time
 
+            breakdown = getattr(model, "loss_breakdown", None)
+            if breakdown:
+                formatted = ", ".join(
+                    f"{name}={value.item():.4f}" if hasattr(value, "item") else f"{name}={value}"
+                    for name, value in breakdown.items()
+                )
+                print(f"    Loss breakdown (last batch): {formatted}")
+
             # Get metrics
             val_metrics = trainer.evaluate(data_bundle.val_loader)
             

--- a/xtylearner/data/nhefs_dataset.py
+++ b/xtylearner/data/nhefs_dataset.py
@@ -58,6 +58,12 @@ def load_nhefs_dataset(
         inds = np.where(np.isnan(X))
         X[inds] = np.take(col_mean, inds[1])
 
+    # Standardise covariates to zero mean and unit variance to stabilise training
+    feature_mean = X.mean(axis=0)
+    feature_std = X.std(axis=0)
+    feature_std = np.where(feature_std < 1e-6, 1.0, feature_std)
+    X = (X - feature_mean) / feature_std
+
     if n_samples is not None:
         rng = np.random.default_rng(seed)
         indices = rng.choice(len(X), n_samples, replace=False)


### PR DESCRIPTION
## Summary
- standardize NHEFS covariates after imputation so benchmark runs receive scaled features

## Testing
- python eval.py --model diffusion_cevae --dataset nhefs --config quick_benchmark_config.json --output diff_nhefs_scaled.json

------
https://chatgpt.com/codex/tasks/task_e_68d730546ef08324a62a8ff58c607f83